### PR TITLE
faster integration tests via pre-hook

### DIFF
--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -111,7 +111,7 @@ class FireboltAdapter(SQLAdapter):
     @classmethod
     def convert_datetime_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         # there's an issue with timestamp currently
-        return 'DATE'
+        return 'TEXT'
 
     @classmethod
     def convert_time_type(cls, agate_table: agate.Table, col_idx: int) -> str:

--- a/test/integration/firebolt.dbtspec
+++ b/test/integration/firebolt.dbtspec
@@ -8,6 +8,28 @@ target:
   schema: "dbt_test_{{ var('_dbt_random_suffix') }}"
   port: 443
   threads: 1
+projects:
+  - overrides: base
+    dbt_project_yml: &override-project
+      name: schema_tests
+      config-version: 2
+      version: '1.0.0'
+      models:
+        dbt_test_project:
+          +pre-hook: "set firebolt_dont_wait_for_upload_to_s3=1"
+      seeds:
+        dbt_test_project:
+          +pre-hook: "set firebolt_dont_wait_for_upload_to_s3=1"
+  - overrides: ephemeral
+    dbt_project_yml: *override-project
+  - overrides: incremental
+    dbt_project_yml: *override-project
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *override-project
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: *override-project
+  - overrides: schema_tests
+    dbt_project_yml: *override-project
 sequences:
   test_dbt_empty: empty
   test_dbt_base: base


### PR DESCRIPTION
this change forces each test to use the `set firebolt_dont_wait_for_upload_to_s3=1` pre-hook. this will make tests run much faster (provided that the driver/SDK allows pre-hook statements)