### PR TITLE
drop the prefixed, dbt-generated metadata comment from SQL statements submitted to firebolt

### DIFF
--- a/dbt/adapters/firebolt/connections.py
+++ b/dbt/adapters/firebolt/connections.py
@@ -12,6 +12,7 @@ from dbt.adapters.base import Credentials
 from dbt.contracts.connection import AdapterResponse
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.clients.agate_helper import table_from_rows
+from dbt.contracts.graph.manifest import Manifest
 
 @dataclass
 class FireboltCredentials(Credentials):
@@ -219,6 +220,9 @@ class FireboltConnectionManager(SQLConnectionManager):
                 row.append(out)
             rows.append(row)
         return table_from_rows(rows=rows, column_names=column_names)
+
+    def set_query_header(self, manifest: Manifest) -> None:
+        self.query_header = None
 
 
 class EngineOfflineException(Exception):


### PR DESCRIPTION
fixes: #16 

drop the dbt-generated query_comment

the following query yields more immediately scannable/readable results
```SQL
SELECT START_TIME, DURATION, STATUS, QUERY_TEXT, ERROR_MESSAGE FROM catalog.query_history WHERE STATUS != 'STARTED_EXECUTION' ORDER BY START_TIME DESC LIMIT 50;
```


<img width="946" alt="image" src="https://user-images.githubusercontent.com/8158673/141968318-ea53601c-888b-4f73-9953-877b79d51f99.png">
