### PR TITLE
add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!---
+  make your PR title be what has changed in the active voice:
+  e.g. "added new macro to enable x" or "fixed run twice bug".
+  The reason is to make auto-generated release notes more valuable because
+  they use PR titles, not descriptions
+-->
+
+<!---
+  Include the number of the issue addressed by this PR above if applicable.
+-->
+resolves #
+
+### Description
+
+<!---
+  Describe the Pull Request here. Why were the changes mades?
+  Add any references and info to help reviewers understand your changes.
+  Include any tradeoffs you considered.
+-->
+
+### Checklist
+
+- [ ] I have run this code in development and it appears to resolve the stated issue
+- [ ] This PR includes tests, or tests are not required/relevant for this PR
+- [ ] I have updated the `CHANGELOG.md` and added information about my change
+- [ ] I have bumped the version if this PR requires a new PyPI release.
+- [ ] I have pulled/merged from the main branch if there are merge conflicts
+- [ ] I have verified that this PR contains only code changes relevant to this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 <!---
-  make your PR title be what has changed in the active voice:
-  e.g. "added new macro to enable x" or "fixed run twice bug".
-  The reason is to make auto-generated release notes more valuable because
-  they use PR titles, not descriptions
+  The PR title should indicate what has changed and should be in the active voice,
+  e.g. "Added new macro to enable x" or "Fixed run twice bug".
+  This makes auto-generated release notes more valuable, as
+  they use PR titles, not descriptions.
 -->
 
 <!---
   Include the number of the issue addressed by this PR above if applicable.
 -->
-resolves #
+Resolves #
 
 ### Description
 
@@ -20,9 +20,9 @@ resolves #
 
 ### Checklist
 
-- [ ] I have run this code in development and it appears to resolve the stated issue
-- [ ] This PR includes tests, or tests are not required/relevant for this PR
-- [ ] I have updated the `CHANGELOG.md` and added information about my change
-- [ ] I have bumped the version if this PR requires a new PyPI release.
-- [ ] I have pulled/merged from the main branch if there are merge conflicts
-- [ ] I have verified that this PR contains only code changes relevant to this PR
+- [ ] I have run this code in development and it appears to resolve the stated issue.
+- [ ] This PR includes tests, or tests are not required/relevant for this PR.
+- [ ] I have updated `CHANGELOG.md` and added information about my change.
+- [ ] If this PR requires a new PyPI release I have bumped the version number.
+- [ ] I have pulled/merged from the main branch if there are merge conflicts.
+- [ ] I have verified that this PR contains only code changes relevant to this PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 - Added linting using Black, Flake8, and iSort. This necessitated the addition of a `setup.cfg` file, so an additional linter, `setup-cfg-fmt` was added to check that file. These linters are all pre-commit hooks, so will force any future commits to abide by our style.
 
+
+### Under the hood
+
+- added GitHub templates for PRs and issues
+
 ## v.0.21.4
 
 ### Changes


### PR DESCRIPTION
this adds a PR template so that when opening a PR, developers are reminded to document their work and follow agreed-upon practices. I used [dbt-core's template](https://raw.githubusercontent.com/dbt-labs/dbt-core/main/.github/pull_request_template.md) as a reference, I'd love feedback on what we need/want here.

sidebar: @kevinmarr we need to get a CLA in place if we want to accept PRs from the community.