### PR TITLE
fix: Fixed missing adapter firebolt error

### DIFF
--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '0.21.8'
+__version__ = '0.21.9'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,


### PR DESCRIPTION
Resolves problems with adapter firebolt not being found after update from 0.21.7 to 0.21.8. 

### Description

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] I have verified that this PR contains only code changes relevant to this PR.
