### PR TITLE
fix: External table models with missing fields now produce an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v.1.0.2
+
+### Under the hood
+
+- Bug fix to check for `data_type` and `regex` fields when necessary on external tables.
+- Changed default behavior on external table insert to `DROP IF EXISTS`.
+
 ## v.1.0.0
 
 - dbt-firebolt now supports dbt 1.0+!

--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '1.0.0'
+__version__ = '1.0.2'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -159,23 +159,24 @@ class FireboltAdapter(SQLAdapter):
         unpartitioned_columns = []
         partitioned_columns = []
         for column in columns:
-            if 'name' in column:
-                if 'data_type' in column:
-                    unpartitioned_columns.append(
-                        self.quote(column['name']) + ' ' + column['data_type']
-                    )
-                else:
-                    raise dbt.exceptions.RuntimeException(
-                        f"Data type is missing for column {column['name']}."
-                    )
+            if 'data_type' in column and column['data_type'] is not None:
+                unpartitioned_columns.append(
+                    self.quote(column['name']) + ' ' + column['data_type']
+                )
             else:
                 raise dbt.exceptions.RuntimeException(
-                    f'Column name is missing or misformatted.'
+                    f"Data type is missing for column {column['name']}."
                 )
         if partitions:  # partitions may be empty.
             for partition in partitions:
-                if 'name' in partition:
-                    if 'data_type' in partition and 'regex' in partition:
+                # Todo: See if name is a required field.
+                if 'name' in partition and partition['name'] is not None:
+                    if (
+                        'data_type' in partition
+                        and 'regex' in partition
+                        and partition['data_type'] is not None
+                        and partition['regex'] is not None
+                    ):
                         partitioned_columns.append(
                             self.quote(partition['name'])
                             + ' '

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -165,7 +165,7 @@ class FireboltAdapter(SQLAdapter):
                 )
             else:
                 raise dbt.exceptions.RuntimeException(
-                    f"Data type is missing for column {column['name']}."
+                    f"Data type is missing for column `{column['name']}`."
                 )
         if partitions:  # partitions may be empty.
             for partition in partitions:
@@ -188,7 +188,7 @@ class FireboltAdapter(SQLAdapter):
                     else:
                         raise dbt.exceptions.RuntimeException(
                             'Either regex or data type is missing for '
-                            f"partition {partition['name']}."
+                            f"partition `{partition['name']}`."
                         )
                 else:  # name is missing
                     raise dbt.exceptions.RuntimeException(

--- a/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
@@ -10,7 +10,7 @@
     -- {%- set partitions = external.partitions -%}
     {%- set credentials = external.credentials -%}
     {# Leaving out "IF NOT EXISTS" because this should only be called by
-       get_external_build_plan *after* a dropif #}
+       if no DROP IF is necessary. #}
     CREATE EXTERNAL TABLE {{source(source_node.source_name, source_node.name)}} (
         {%- for column in columns -%}
           {{ column }}

--- a/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
@@ -5,16 +5,13 @@
         schema = source_node.schema,
         identifier = source_node.identifier
     ) %}
-    {% set create_or_replace = (old_relation is none or var('ext_full_refresh', false)) %}
-    {% if create_or_replace %}
-        {% set build_plan = [
-               dropif(source_node),
-               create_external_table(source_node)
-
-           ]
-        %}
+    {# var(variable, Boolean) if `variable` isn't set defaults to Boolean value.
+       So the default action below is to do a full refresh. #}
+    {% if old_relation is not none and var('ext_full_refresh', True) %}
+        {% set build_plan = build_plan + [dropif(source_node),
+                                          create_external_table(source_node)] %}
     {% else %}
-        {% set build_plan = dbt_external_tables.refresh_external_table(source_node) %}
+        {% set build_plan = build_plan + [create_external_table(source_node)] %}
     {% endif %}
     {% do return(build_plan) %}
 {% endmacro %}

--- a/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
@@ -5,13 +5,14 @@
         schema = source_node.schema,
         identifier = source_node.identifier
     ) %}
-    {# var(variable, Boolean) if `variable` isn't set defaults to Boolean value.
-       So the default action below is to do a full refresh. #}
-    {% if old_relation is not none and var('ext_full_refresh', True) %}
+    {# var(variable, Boolean) defaults to Boolean value if `variable` isn't set.
+       Firebolt doesn't do refresh because we don't need to—external tables will always
+       pull most recent data from S3, so the default action below is to skip. #}
+    {% if old_relation is none or var('ext_full_refresh', false) %}
         {% set build_plan = build_plan + [dropif(source_node),
                                           create_external_table(source_node)] %}
     {% else %}
-        {% set build_plan = build_plan + [create_external_table(source_node)] %}
+        {% set build_plan = dbt_external_tables.refresh_external_table(source_node) %}
     {% endif %}
     {% do return(build_plan) %}
 {% endmacro %}


### PR DESCRIPTION
### Description

Previously, external table models with missing or misspelled `regex` or `data_type` fields caused indecipherable errors. Those errors are now clear. In addition, drop/create on external tables only occurs if variable is set: `dbt run-operation stage_external_sources  --vars "ext_full_refresh: true"`. Otherwise, table is skipped.

### Fixes
[dbt seeds doesn't truncate tables before running](https://packboard.atlassian.net/browse/FIR-10985)

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue.
- [X] This PR includes tests, or tests are not required/relevant for this PR.
- [X] I have updated `CHANGELOG.md` and added information about my change.
- [X] If this PR requires a new PyPI release I have bumped the version number.
- [X] I have pulled/merged from the main branch if there are merge conflicts.
- [X] I have verified that this PR contains only code changes relevant to this PR.
