### PR TITLE
fix: Moved all dev-requirements into setup.cfg.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,0 @@
-pytest~=0.6.2
-pytest-dbt-adapter==0.6.0
-dbt-core~=1.0
-isort>=5.10
-flake8>=4.0
-black>=21.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,10 @@ include = dbt, dbt.*
 
 [options.extras_require]
 dev =
+    black>=21.10
+    dbt-core~=1.0
+    flake8>=4.0
+    isort>=5.10
     mypy>=0.910
     pre-commit==2.15.0
     pytest==6.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
-    firebolt-sdk>=0.5.2
+    firebolt-sdk>=0.6
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ include = dbt, dbt.*
 [options.extras_require]
 dev =
     black>=21.10
-    dbt-core~=1.0
     flake8>=4.0
     isort>=5.10
     mypy>=0.910


### PR DESCRIPTION
### Description

<!---
    Moved dev requirements into setup.cfg so fossa won't complain about unregistered `pytest-dbt-adapters`.
-->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
