### PR TITLE
fix: Updated version number and changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v.1.0.3
+
+### Under the hood
+
+- Dev requirements are now in setup.cfg and not dev-requirements.txt.
+- dbt-firebolt now requires firebolt-sdk v.0.6 to allow for SET variables to be set in pre-hooks.
+
 ## v.1.0.2
 
 ### Under the hood

--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,


### PR DESCRIPTION
### Description

Changelog and version number were inadvertently left at v1.0.2 and needed to be v1.0.3.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
