### PR TITLE
style: Better log and debug output

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!---
   The PR title should indicate what has changed and should be in the active voice,
   e.g. "Added new macro to enable x" or "Fixed run twice bug".
-  This makes auto-generated release notes more valuable, as they use PR titles, 
+  This makes auto-generated release notes more valuable, as they use PR titles,
   not descriptions. Note that PR titles must be prefixed with specific _lowercased_
   prefixes followed by a colon. Allowable prefixes are:
   • feat: A new feature
@@ -35,6 +35,7 @@ Resolves #
 - [ ] I have run this code in development and it appears to resolve the stated issue.
 - [ ] This PR includes tests, or tests are not required/relevant for this PR.
 - [ ] I have updated `CHANGELOG.md` and added information about my change.
+- [ ] I have removed any print or log calls that were added for debugging.
 - [ ] If this PR requires a new PyPI release I have bumped the version number.
 - [ ] I have verified that this PR contains only code changes relevant to this PR.
 - [ ] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Under the hood
+
+- Rendering of SQL output was reformatted to increase legibility of debug output and log files.
+
 ## v.1.0.3
 
 ### Under the hood

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -188,7 +188,6 @@ class FireboltAdapter(SQLAdapter):
                     + partition['regex']
                     + "')"
                 )
-
         return unpartitioned_columns + partitioned_columns
 
     @available.parse_none

--- a/dbt/adapters/firebolt/relation.py
+++ b/dbt/adapters/firebolt/relation.py
@@ -31,6 +31,6 @@ class FireboltRelation(BaseRelation):
         if self.include_policy.database and self.include_policy.schema:
             raise RuntimeException(
                 'Got a Firebolt relation with schema and database set to '
-                'include, but only one can be set'
+                'include, but only one can be set.'
             )
         return super().render()

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -91,6 +91,7 @@
 
 {% macro drop_index(index_name, index_type) -%}
     {% call statement('drop_relation', auto_begin=False) %}
+
         DROP {{ index_type | upper }} INDEX "{{ index_name }}"
     {% endcall %}
 {% endmacro %}
@@ -202,7 +203,8 @@
 
 {% macro firebolt__snapshot_string_as_time(timestamp) -%}
     {% call statement('timestamp', fetch_result=True) %}
+
         SELECT CAST('{{ timestamp }}' AS DATE)
     {% endcall %}
     {{ return(load_result('timestamp').table) }}
-{%- endmacro %}
+{% endmacro %}

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -1,6 +1,6 @@
 {% macro firebolt__drop_schema(schema_relation) -%}
-  {# until schemas are supported #}
-  {# this macro will drop all tables and views #}
+  {# until schemas are supported
+     this macro will drop all tables and views #}
   {% set relations = (list_relations_without_caching(schema_relation)) %}
 
   {% set vews = adapter.filter_table(relations, 'type', 'view') %}
@@ -15,8 +15,7 @@
     {%- set relation = api.Relation.create(database=target.database,
                                            schema=target.schema,
                                            identifier=row[1],
-                                           type=row[3]
-                                           ) -%}
+                                           type=row[3]) -%}
     {% do drop_relation(relation) %}
   {%- endfor %}
 {% endmacro %}
@@ -24,9 +23,11 @@
 
 {% macro firebolt__list_schemas(database) %}
     {% if target.threads > 1 %}
-        {{ exceptions.raise_compiler_error("Firebolt does not currently support more than one thread.") }}
+        {{ exceptions.raise_compiler_error("Firebolt does not currently support "
+                                           "more than one thread.") }}
     {% endif %}
     {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
+
         SELECT '{{target.schema}}' AS schema
     {% endcall %}
     {{ return(load_result('list_schemas').table) }}
@@ -35,20 +36,23 @@
 
 {% macro firebolt__create_schema(relation) -%}
 {# stub. Not yet supported in Firebolt. #}
-    {%- call statement('create_schema') -%}
-        SELECT 'create_schema'
+    {%- call statement('create_schema') %}
+
+        SELECT 1
     {% endcall %}
 {% endmacro %}
 
 
-{% macro firebolt__current_timestamp() -%}
+{% macro firebolt__current_timestamp() %}
+
     NOW()
-{%- endmacro %}
+{% endmacro %}
 
 
 {% macro firebolt__alter_column_type(relation, column_name, new_column_type) -%}
     {# stub #}
     {% call statement('alter_column_type') %}
+
         SELECT 'alter_column_type'
     {% endcall %}
 {% endmacro %}
@@ -57,7 +61,8 @@
 {% macro firebolt__check_schema_exists(information_schema, schema) -%}
     {# stub. Not yet supported in Firebolt. #}
     {% call statement('check_schema_exists', fetch_result=True, auto_begin=True) %}
-        SELECT 'schema_exists'
+
+        SELECT 1
     {% endcall %}
     {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}
@@ -81,13 +86,13 @@
             {{ other_col }}
         {%- endif -%}
     );
-{%- endmacro %}
+{% endmacro %}
 
 
 {% macro drop_index(index_name, index_type) -%}
-    {% call statement('drop_relation', auto_begin=False) -%}
+    {% call statement('drop_relation', auto_begin=False) %}
         DROP {{ index_type | upper }} INDEX "{{ index_name }}"
-    {%- endcall %}
+    {% endcall %}
 {% endmacro %}
 
 
@@ -114,6 +119,7 @@
 
 {% macro firebolt__get_columns_in_relation(relation) -%}
     {% call statement('get_columns_in_relation', fetch_result=True) %}
+
         SELECT column_name,
                data_type,
                character_maximum_length,
@@ -128,7 +134,8 @@
 
 
 {% macro firebolt__list_relations_without_caching(schema_relation) %}
-    {% call statement('list_tables_without_caching', fetch_result=True) -%}
+    {% call statement('list_tables_without_caching', fetch_result=True) %}
+
         SELECT '{{ schema_relation.database }}' AS "database",
                table_name AS "name",
                '{{ schema_relation.schema }}' AS "schema",
@@ -145,7 +152,8 @@
                                          schema_relation) %}
     {% if (table_info_table.rows | length) > 0
        or (view_info_table_tweaked.rows | length) > 0 %}
-          {{ return(adapter.stack_tables([table_info_table, view_info_table_tweaked])) }}
+          {{ return(adapter.stack_tables([table_info_table,
+                                          view_info_table_tweaked])) }}
     {% else %}
         {{ return(table_info_table) }}
     {% endif %}
@@ -155,7 +163,7 @@
 {% macro firebolt__create_table_as(temporary, relation, sql) -%}
     {# Create table using CTAS #}
     {%- set table_type = config.get('table_type', default='dimension') | upper -%}
-    {%- set primary_index = config.get('primary_index') -%}
+    {%- set primary_index = config.get('primary_index') %}
 
     CREATE {{ table_type }} TABLE IF NOT EXISTS {{ relation }}
     {%- if primary_index %}
@@ -169,10 +177,11 @@
     AS (
         {{ sql }}
     )
-{%- endmacro %}
+{% endmacro %}
 
 
-{% macro firebolt__create_view_as(relation, sql) -%}
+{% macro firebolt__create_view_as(relation, sql) %}
+
     CREATE VIEW IF NOT EXISTS {{ relation.identifier }} AS (
         {{ sql }}
     )
@@ -184,7 +193,8 @@
    This should only be called from reset_csv_table, where it's followed by
    `create_csv_table`, so not recreating the table here. To retrieve old code,
    see commit f9984f6d61b8a1b877bc107b102eeb30eba54f35 #}
-    {% call statement('table_schema') -%}
+    {% call statement('table_schema') %}
+
         DROP TABLE {{ relation.identifier }} CASCADE
-    {%- endcall %}
+    {% endcall %}
 {% endmacro %}

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -38,7 +38,7 @@
 {# stub. Not yet supported in Firebolt. #}
     {%- call statement('create_schema') %}
 
-        SELECT 1
+        SELECT 'create_schema'
     {% endcall %}
 {% endmacro %}
 
@@ -62,7 +62,7 @@
     {# stub. Not yet supported in Firebolt. #}
     {% call statement('check_schema_exists', fetch_result=True, auto_begin=True) %}
 
-        SELECT 1
+        SELECT 'schema_exists'
     {% endcall %}
     {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}
@@ -198,3 +198,11 @@
         DROP TABLE {{ relation.identifier }} CASCADE
     {% endcall %}
 {% endmacro %}
+
+
+{% macro firebolt__snapshot_string_as_time(timestamp) -%}
+    {% call statement('timestamp', fetch_result=True) %}
+        SELECT CAST('{{ timestamp }}' AS DATE)
+    {% endcall %}
+    {{ return(load_result('timestamp').table) }}
+{%- endmacro %}

--- a/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
@@ -7,7 +7,6 @@
         {%- set columns = adapter.make_field_partition_pairs(source_node.columns.values(),
                                                              []) -%}
     {%- endif -%}
-    -- {%- set partitions = external.partitions -%}
     {%- set credentials = external.credentials -%}
     {# Leaving out "IF NOT EXISTS" because this should only be called by
        if no DROP IF is necessary. #}

--- a/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
@@ -7,6 +7,7 @@
         {%- set columns = adapter.make_field_partition_pairs(source_node.columns.values(),
                                                              []) -%}
     {%- endif -%}
+    -- {%- set partitions = external.partitions -%}
     {%- set credentials = external.credentials -%}
     {# Leaving out "IF NOT EXISTS" because this should only be called by
        if no DROP IF is necessary. #}

--- a/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
@@ -6,7 +6,7 @@
         identifier = source_node.identifier
     ) %}
     {# var(variable, Boolean) defaults to Boolean value if variable isnt set.
-       Firebolt doesnt do refresh because we dont need to—external tables will always
+       Firebolt doesn't do refresh because we don't need to—external tables will always
        pull most recent data from S3, so the default action below is to skip. #}
     {% if old_relation is none or var('ext_full_refresh', false) %}
         {% set build_plan = build_plan + [dropif(source_node),

--- a/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/get_external_build_plan.sql
@@ -7,7 +7,6 @@
     ) %}
     {# var(variable, Boolean) defaults to Boolean value if variable isnt set.
        Firebolt doesnt do refresh because we dont need to—external tables will always
-
        pull most recent data from S3, so the default action below is to skip. #}
     {% if old_relation is none or var('ext_full_refresh', false) %}
         {% set build_plan = build_plan + [dropif(source_node),

--- a/dbt/include/firebolt/macros/materializations/seed.sql
+++ b/dbt/include/firebolt/macros/materializations/seed.sql
@@ -8,6 +8,7 @@
     {%- set column_override = model['config'].get('column_types', {}) -%}
     {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
     {% set sql %}
+
       CREATE DIMENSION TABLE IF NOT EXISTS {{ this.render() }} (
           {%- for col_name in agate_table.column_names -%}
               {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
@@ -18,13 +19,14 @@
           {%- endfor -%}
       )
     {% endset %}
-    {% call statement('_') -%}
+    {% call statement('_') %}
         {{ sql }}
     {%- endcall %}
     {{ return(sql) }}
 {% endmacro %}
 
 
+{# TODO: Make sure this is going to run correctly, or delete it. #}
 {% macro firebolt__reset_csv_table(model,
                                    full_refresh,
                                    old_relation,

--- a/dbt/include/firebolt/macros/materializations/table.sql
+++ b/dbt/include/firebolt/macros/materializations/table.sql
@@ -1,6 +1,5 @@
 {% materialization table, adapter='firebolt' %}
-{# Note that a nearly identical materialization appears
-   in table.sql #}
+{# Note that a nearly identical materialization appears in table.sql. #}
   {%- set identifier = model['alias'] -%} {# alias comes from where? #}
 
   {# Temporary workaround to issue with adapter.get_relation() until

--- a/dbt/include/firebolt/macros/materializations/test.sql
+++ b/dbt/include/firebolt/macros/materializations/test.sql
@@ -5,11 +5,10 @@
     {% set old_relation = adapter.get_relation(database=database,
                                                schema=schema,
                                                identifier=identifier) %}
-    {% set target_relation = api.Relation.create(
-        identifier=identifier,
-        schema=schema,
-        database=database,
-        type='table') -%}
+    {% set target_relation = api.Relation.create(identifier=identifier,
+                                                 schema=schema,
+                                                 database=database,
+                                                 type='table') -%}
 
     {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
     {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}

--- a/dbt/include/firebolt/macros/materializations/view.sql
+++ b/dbt/include/firebolt/macros/materializations/view.sql
@@ -15,9 +15,9 @@
                                                 identifier=identifier,
                                                 type='view') -%}
   {%- set target_relation_table = api.Relation.create(database=database,
-                                                     schema=schema,
-                                                     identifier=identifier,
-                                                     type='table') -%}
+                                                      schema=schema,
+                                                      identifier=identifier,
+                                                      type='table') -%}
 
   {{ run_hooks(pre_hooks) }}
 

--- a/tests/integration/firebolt.dbtspec
+++ b/tests/integration/firebolt.dbtspec
@@ -16,12 +16,11 @@ sequences:
   test_dbt_schema_test: schema_test
   test_dbt_data_test: data_test
 
-
 # These aren't passing yet.
+ # test_dbt_incremental: incremental
  # test_dbt_base: base
  # test_dbt_ephemeral: ephemeral
  # test_dbt_ephemeral_data_tests: data_test_ephemeral_models
- # test_dbt_incremental: incremental
 
 # These are only needed for saving state in the DB, so maybe not
 # necessary for v1.

--- a/tests/integration/firebolt.dbtspec
+++ b/tests/integration/firebolt.dbtspec
@@ -17,10 +17,10 @@ sequences:
   test_dbt_data_test: data_test
 
 # These aren't passing yet.
- # test_dbt_incremental: incremental
  # test_dbt_base: base
  # test_dbt_ephemeral: ephemeral
  # test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+ # test_dbt_incremental: incremental
 
 # These are only needed for saving state in the DB, so maybe not
 # necessary for v1.


### PR DESCRIPTION
### Description

Insures that all SQL commands in debug and log output have appropriate space before and after for ease of reading. Also some comment and style cleanup.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
