### PR TITLE
fix: Removed SHOW VIEWS and SHOW TABLES from all code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v.1.0.5
+
+### Under the hood
+
+- Removed all uses of `SHOW VIEWS` and `SHOW TABLES` and replaced them with calls to information_schema.views and information_schema.tables, respectively.
+
 ## v.1.0.4
 
 ### Under the hood

--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -126,31 +126,6 @@ class FireboltAdapter(SQLAdapter):
         )
 
     @available.parse_none
-    def reformat_view_results(self, agate_table, schema_relation) -> agate.Table:
-        """
-        Tweak `SHOW VIEWS` to match the output of information_schema.tables
-        before they are unioned.
-        """
-
-        def form_sing_val_col(string_val) -> agate.Formula:
-            """Return wrapper for creating agate.Formula objects"""
-            return agate.Formula(agate.Text(), lambda r: string_val)
-
-        agate_new = (
-            agate_table.exclude(['schema'])
-            .rename(column_names={'view_name': 'name'})
-            .compute(
-                [
-                    ('database', form_sing_val_col(schema_relation.database)),
-                    ('schema', form_sing_val_col(schema_relation.schema)),
-                    ('type', form_sing_val_col('view')),
-                ]
-            )
-            .select(['database', 'name', 'schema', 'type'])
-        )
-        return agate_new
-
-    @available.parse_none
     def make_field_partition_pairs(self, columns, partitions) -> List[str]:
         """
         Return a list of strings of form "column column_type" or

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -142,22 +142,15 @@
                '{{ schema_relation.schema }}' AS "schema",
                'table' AS type
           FROM information_schema.tables
+        UNION
+        SELECT '{{ schema_relation.database }}' AS "database",
+               table_name AS "name",
+               '{{ schema_relation.schema }}' AS "schema",
+               'view' AS type
+          FROM information_schema.views
     {% endcall %}
-    {% set table_info_table = load_result('list_tables_without_caching').table %}
-    {% call statement('list_views_without_caching', fetch_result=True) -%}
-        SHOW VIEWS
-    {% endcall %}
-    {% set view_info_table = load_result('list_views_without_caching').table %}
-    {% set view_info_table_tweaked = adapter.reformat_view_results(
-                                         view_info_table,
-                                         schema_relation) %}
-    {% if (table_info_table.rows | length) > 0
-       or (view_info_table_tweaked.rows | length) > 0 %}
-          {{ return(adapter.stack_tables([table_info_table,
-                                          view_info_table_tweaked])) }}
-    {% else %}
-        {{ return(table_info_table) }}
-    {% endif %}
+    {% set info_table = load_result('list_tables_without_caching').table %}
+    {{ return(info_table) }}
 {% endmacro %}
 
 

--- a/dbt/include/firebolt/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/firebolt/macros/materializations/models/incremental/merge.sql
@@ -13,4 +13,3 @@
         SELECT {{ dest_cols_csv }}
         FROM {{ source }}
 {%- endmacro %}
-


### PR DESCRIPTION
Resolves https://packboard.atlassian.net/browse/FIR-10760

### Description

Removed all uses of `SHOW VIEWS` and `SHOW TABLES` and replaced them with calls to information_schema.views and information_schema.tables, respectively. This both cleans up the code and allows for the removal of some hideous hoops we had to jump through to harmonize catalog queries and queries listing all relations.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] I have removed any print or log calls that were added for debugging.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
