### PR TITLE
fix: Correctly format index names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Rendering of SQL output was reformatted to increase legibility of debug output and log files.
 - Removed all uses of `SHOW VIEWS` and `SHOW TABLES` and replaced them with calls to information_schema.views and information_schema.tables, respectively.
 - Updated to give better/more accurate responses from cursor.
+- Fixed an error where names for aggregating and join indexes with only single values for indexes were being improperly generated.
 
 ## v.1.0.3
 

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -40,11 +40,13 @@ class FireboltIndexConfig(dbtClassMixin):
         else:
             # Must be join column
             column_names = self.join_column
-        spine_col = (
-            '_'.join(column_names)
-            if type(column_names) is list and type(column_names) > 1
-            else column_names
-        )
+        if type(column_names) is str:
+            spine_col = column_names
+        elif len(column_names) > 1:
+            spine_col = '_'.join(column_names)
+        else:
+            # column_names is a list with a single member.
+            spine_col = column_names[0]
         inputs = [
             f'{self.index_type}_idx',
             relation.identifier,

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -125,13 +125,13 @@
       {{ make_create_index_sql(relation,
                                index_name,
                                "CREATE JOIN INDEX",
-                               index_config.join_column,
+                               index_config.join_columns,
                                index_config.dimension_column) }}
   {%- elif index_type == "AGGREGATING" -%}
       {{ make_create_index_sql(relation,
                                index_name,
                                "CREATE AND GENERATE AGGREGATING INDEX",
-                               index_config.key_column,
+                               index_config.key_columns,
                                index_config.aggregation) }}
   {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
<!---
  The PR title should indicate what has changed and should be in the active voice,
  e.g. "Added new macro to enable x" or "Fixed run twice bug".
  This makes auto-generated release notes more valuable, as they use PR titles,
  not descriptions. Note that PR titles must be prefixed with specific _lowercased_
  prefixes followed by a colon. Allowable prefixes are:
  • feat: A new feature
  • fix: A bug fix
  • docs: Documentation-only changes
  • style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  • refactor: A code change that neither fixes a bug nor adds a feature
  • perf: A code change that improves performance
  • test: Adding missing tests or correcting existing tests
  • build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  • ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  • chore: Other changes that don't modify src or test files
  • revert: Reverts a previous commit
-->

### Description

Updated logic in FireboltIndexConfig.parse() in impl.py to deal with situations where key columns have only a single value. Index names are now formatted properly.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] I have removed any print or log calls that were added for debugging.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
