### PR TITLE
build: require dbt1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v.1.0.6
+
+### Under the hood
+
+- dbt-firebolt now requires dbt v1.1.
+- dbt-firebolt now requires firebolt-sdk>=0.7
+
+### Breaking changes
+
+- dbt-firebolt now requires dbt v1.1
+
 ## v.1.0.5
 
 ### Under the hood

--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     mypy==0.910
     pre-commit==2.15.0
     pytest==6.2.5
-    pytest-dbt-adapter~=1.1
+    pytest-dbt-adapter~=0.6.0
 
 [flake8]
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
+    dbt-core~=1.1
     firebolt-sdk>=0.7
 python_requires = >=3.7
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     mypy==0.910
     pre-commit==2.15.0
     pytest==6.2.5
-    pytest-dbt-adapter==0.6.0
+    pytest-dbt-adapter~=1.1
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools.config import read_configuration
 
 config = read_configuration('setup.cfg')
 version = config['metadata']['version']
-dbt_version = version.rsplit('.', 1)[0]
-install_requires = [f'dbt-core~={dbt_version}', config['options']['install_requires']]
+install_requires = config['options']['install_requires']
 
 setup(install_requires=install_requires)


### PR DESCRIPTION
Resolves FIR-13208

### Description

Moved the base requirement to dbt v1.1. This is in preparation for moving to the new testing suite that dbt has provided as of dbt v1.1.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] I have removed any print or log calls that were added for debugging.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
