### PR TITLE
feat: pass better error messages when API times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v.1.1.2
+
+### Features
+
+- dbt-firebolt now passes through more useful error messages on API timeouts.
+
+### Under the hood
+
+- dbt-firebolt now requires firebolt-sdk>=0.10.0.
+
 ## v.1.1.1
 
 ### Under the hood

--- a/dbt/adapters/firebolt/__init__.py
+++ b/dbt/adapters/firebolt/__init__.py
@@ -4,7 +4,7 @@ from dbt.adapters.firebolt.connections import FireboltCredentials
 from dbt.adapters.firebolt.impl import FireboltAdapter
 from dbt.include import firebolt
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 Plugin = AdapterPlugin(
     adapter=FireboltAdapter,

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 packages = find_namespace:
 install_requires =
     dbt-core~=1.1
-    firebolt-sdk@git+https://github.com/firebolt-db/firebolt-python-sdk@update-interface-error-message
+    firebolt-sdk>=0.10.0
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 packages = find_namespace:
 install_requires =
     dbt-core~=1.1
-    firebolt-sdk>=0.9.2
+    firebolt-sdk@git+https://github.com/firebolt-db/firebolt-python-sdk@update-interface-error-message
 python_requires = >=3.7
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Resolves https://packboard.atlassian.net/browse/FIR-15597

### Description

<!---
  Deals with occasional issues with timeouts coming from the API. Correct error messages are now passed through.
-->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] I have removed any print or log calls that were added for debugging.
- [x] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited firebolt.dbtspec to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated firebolt.dbtspec.
