### PR TITLE
test: Fixing catalog error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- get_catalog now returns database and schema names along with the column indexes
+
 ### Under the hood
 
 - Using new test framework

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,30 @@ def dbt_profile_target():
         'engine_name': os.getenv('ENGINE_NAME'),
         'user': os.getenv('USER_NAME'),
         'password': os.getenv('PASSWORD'),
-        'schema': 'test',
         'port': 443,
     }
+
+
+@pytest.fixture(scope="class")
+def dbt_profile_data(dbt_profile_target, profiles_config_update):
+    """
+    Overriding dbt_profile_data in order to set the schema to public.
+    Firebolt does not have concept of schemas so this is necessary for
+    the test to pass.
+    """
+    profile = {
+        "config": {"send_anonymous_usage_stats": False},
+        "test": {
+            "outputs": {
+                "default": {},
+            },
+            "target": "default",
+        },
+    }
+    target = dbt_profile_target
+    target["schema"] = 'public' # Different from dbt-core in here
+    profile["test"]["outputs"]["default"] = target
+
+    if profiles_config_update:
+        profile.update(profiles_config_update)
+    return profile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,25 +24,23 @@ def dbt_profile_target():
     }
 
 
-@pytest.fixture(scope="class")
+# Overriding dbt_profile_data in order to set the schema to public.
+# Firebolt does not have concept of schemas so this is necessary for
+# the test to pass.
+@pytest.fixture(scope='class')
 def dbt_profile_data(dbt_profile_target, profiles_config_update):
-    """
-    Overriding dbt_profile_data in order to set the schema to public.
-    Firebolt does not have concept of schemas so this is necessary for
-    the test to pass.
-    """
     profile = {
-        "config": {"send_anonymous_usage_stats": False},
-        "test": {
-            "outputs": {
-                "default": {},
+        'config': {'send_anonymous_usage_stats': False},
+        'test': {
+            'outputs': {
+                'default': {},
             },
-            "target": "default",
+            'target': 'default',
         },
     }
     target = dbt_profile_target
-    target["schema"] = 'public' # Different from dbt-core in here
-    profile["test"]["outputs"]["default"] = target
+    target['schema'] = 'public'  # Different from dbt-core in here
+    profile['test']['outputs']['default'] = target
 
     if profiles_config_update:
         profile.update(profiles_config_update)

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -17,7 +17,6 @@ from dbt.tests.adapter.basic.test_snapshot_timestamp import (
 from pytest import mark
 
 
-@mark.skip('Requires investigation')
 class TestSimpleMaterializationsFirebolt(BaseSimpleMaterializations):
     pass
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -33,12 +33,10 @@ class TestEmptyFirebolt(BaseEmpty):
     pass
 
 
-@mark.skip('Requires catalog fix')
 class TestEphemeralFirebolt(BaseEphemeral):
     pass
 
 
-@mark.skip('Requires catalog fix')
 class TestIncrementalFirebolt(BaseIncremental):
     pass
 


### PR DESCRIPTION

### Description

Catalog error was due to dbt tests assigning unique schema name to each run. We do not have schemas in Firebolt so when tests filtered results based on unique schema they got no data and failed down the line.
This extracts `table_schema` from `information_schema`, which is always set to `public`. Also `table_catalog` contains database name.

This change allows 3 more tests to pass.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated `CHANGELOG.md` and added information about my change.
- [x] I have removed any print or log calls that were added for debugging.
- [ ] If this PR requires a new PyPI release I have bumped the version number.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/test_basic.py to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/test_basic.py.
