### PR TITLE
test: Adding grant tests

### DIFF
--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -197,6 +197,17 @@ class FireboltAdapter(SQLAdapter):
             )
 
     @available.parse_none
+    def raise_grant_error(self) -> None:
+        """
+        Grant is not currently supported so this function
+            raises an error.
+        """
+        dbt.exceptions.raise_compiler_error(
+            'Firebolt does not support table-level permission grants.'
+            ' Please remove grants section from the config.'
+        )
+
+    @available.parse_none
     def sdk_column_list_to_firebolt_column_list(
         self, columns: List[SDKColumn]
     ) -> List[FireboltColumn]:

--- a/dbt/include/firebolt/macros/adapters/apply_grants.sql
+++ b/dbt/include/firebolt/macros/adapters/apply_grants.sql
@@ -1,0 +1,25 @@
+{% macro firebolt__get_show_grant_sql(relation) %}
+    {{ adapter.raise_grant_error() }}
+{% endmacro %}
+
+
+{%- macro firebolt__get_grant_sql(relation, privilege, grantee) -%}
+    {{ adapter.raise_grant_error() }}
+{%- endmacro -%}
+
+
+{%- macro firebolt__get_revoke_sql(relation, privilege, grantee) -%}
+    {{ adapter.raise_grant_error() }}
+{%- endmacro -%}
+
+
+{% macro firebolt__copy_grants() %}
+    {{ adapter.raise_grant_error() }}
+{% endmacro %}
+
+
+{% macro firebolt__apply_grants(relation, grant_config, should_revoke) %}
+    {% if grant_config %}
+        {{ adapter.raise_grant_error() }}
+    {% endif %}
+{% endmacro %}

--- a/dbt/include/firebolt/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/firebolt/macros/materializations/models/incremental/incremental.sql
@@ -19,6 +19,9 @@
   {# Not yet used
     {% set unique_key = config.get('unique_key') %}
   #}
+
+  {% set grant_config = config.get('grants') %}
+
   {%- set strategy = config.get('incremental_strategy') -%}
   {%- if is_incremental() and strategy is none -%}
     {{ log('Model %s is set to incremental, but no incremental strategy is set. '
@@ -80,6 +83,9 @@
   {%- call statement("main") -%}
     {{ build_sql }}
   {%- endcall -%}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
 
   {# Todo: figure out what persist_docs and create_indexes do. #}
   {%- do persist_docs(target, model) -%}

--- a/dbt/include/firebolt/macros/materializations/table.sql
+++ b/dbt/include/firebolt/macros/materializations/table.sql
@@ -18,6 +18,8 @@
                                                      identifier=identifier,
                                                      type='view') -%}
 
+  {%- set grant_config = config.get('grants') -%}
+
   {{ run_hooks(pre_hooks) }}
 
   {% do adapter.drop_relation(target_relation) %}
@@ -29,6 +31,9 @@
   {%- endcall %}
   {% do create_indexes(target_relation) %}
   {{ run_hooks(post_hooks) }}
+
+  {% set should_revoke = should_revoke(old_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}
   {{ return({'relations': [target_relation]}) }}

--- a/dbt/include/firebolt/macros/materializations/view.sql
+++ b/dbt/include/firebolt/macros/materializations/view.sql
@@ -18,6 +18,7 @@
                                                       schema=schema,
                                                       identifier=identifier,
                                                       type='table') -%}
+  {%- set grant_config = config.get('grants') -%}
 
   {{ run_hooks(pre_hooks) }}
 
@@ -29,6 +30,9 @@
     {{ create_view_as(target_relation, sql) }}
   {%- endcall %}
   {{ run_hooks(post_hooks) }}
+
+  {% set should_revoke = should_revoke(old_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}
   {{ return({'relations': [target_relation]}) }}

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -1,0 +1,38 @@
+from dbt.tests.adapter.grants.base_grants import BaseGrants
+from dbt.tests.adapter.grants.test_incremental_grants import (
+    BaseIncrementalGrants,
+)
+from dbt.tests.adapter.grants.test_invalid_grants import BaseInvalidGrants
+from dbt.tests.adapter.grants.test_model_grants import BaseModelGrants
+from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
+from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
+from pytest import mark
+
+
+class BaseGrantsFirebolt(BaseGrants):
+    pass
+
+
+@mark.skip('Table-level grants are not supported yet in Firebolt')
+class TestModelGrantsFirebolt(BaseGrantsFirebolt, BaseModelGrants):
+    pass
+
+
+@mark.skip('Table-level grants are not supported yet in Firebolt')
+class TestIncrementalGrantsFirebolt(BaseGrantsFirebolt, BaseIncrementalGrants):
+    pass
+
+
+@mark.skip('Table-level grants are not supported yet in Firebolt')
+class TestSeedGrantsFirebolt(BaseGrantsFirebolt, BaseSeedGrants):
+    pass
+
+
+@mark.skip('Table-level grants are not supported yet in Firebolt')
+class TestSnapshotGrantsFirebolt(BaseGrantsFirebolt, BaseSnapshotGrants):
+    pass
+
+
+@mark.skip('Table-level grants are not supported yet in Firebolt')
+class TestInvalidGrantsFirebolt(BaseGrantsFirebolt, BaseInvalidGrants):
+    pass

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -3,14 +3,50 @@ from dbt.tests.adapter.grants.test_incremental_grants import (
     BaseIncrementalGrants,
 )
 from dbt.tests.adapter.grants.test_invalid_grants import BaseInvalidGrants
-from dbt.tests.adapter.grants.test_model_grants import BaseModelGrants
+from dbt.tests.adapter.grants.test_model_grants import (
+    BaseModelGrants,
+    model_schema_yml,
+    my_model_sql,
+    table_model_schema_yml,
+)
 from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
-from pytest import mark
+from dbt.tests.util import run_dbt_and_capture, write_file
+from pytest import fixture, mark
 
 
 class BaseGrantsFirebolt(BaseGrants):
     pass
+
+
+class TestGrantsFailWithException(BaseGrants):
+    """
+    Verify compile-time errors when trying to use
+    grant functionality in Firebolt.
+    """
+
+    @fixture(scope='class')
+    def models(self):
+        updated_schema = self.interpolate_name_overrides(model_schema_yml)
+        return {
+            'my_model.sql': my_model_sql,
+            'schema.yml': updated_schema,
+        }
+
+    def test_view_table_grants(self, project, get_test_users):
+        # View materialization, single select grant
+        (results, log_output) = run_dbt_and_capture(
+            ['--debug', 'run'], expect_pass=False
+        )
+        assert 'Firebolt does not support table-level permission grants' in log_output
+
+        # Table materialization, single select grant
+        updated_yaml = self.interpolate_name_overrides(table_model_schema_yml)
+        write_file(updated_yaml, project.project_root, 'models', 'schema.yml')
+        (results, log_output) = run_dbt_and_capture(
+            ['--debug', 'run'], expect_pass=False
+        )
+        assert 'Firebolt does not support table-level permission grants' in log_output
 
 
 @mark.skip('Table-level grants are not supported yet in Firebolt')


### PR DESCRIPTION
Ref #71 

### Description

Adding placeholders for Grant tests. Since Firebolt does not support table-level permissions we can't really test the above.
We're throwing an error when explicitly trying to set grants so there's no unexpected functionality for the user.