### PR TITLE
perf: Using views for temp ops in incremental

### DIFF
--- a/.changes/unreleased/Changed-20230213-140852.yaml
+++ b/.changes/unreleased/Changed-20230213-140852.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Using temp views instead of temp tables in incremental for performance
+time: 2023-02-13T14:08:52.423048Z

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -12,10 +12,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check title name convention
-        uses: jef/conventional-commits-pr-action@v1.0.0
+        uses: jef/conventional-commits-pr-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - --remove-unused-variables
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
-    dbt-core~=1.2
+    dbt-core~=1.2,<1.4
     firebolt-sdk>=0.10.0
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
### Description

FIR-17190

Views are supposed to be more performant when used for the purpose of resolving columns. This also avoids creating a lot of "garbage" by repeatedly creating/deleting tables.
Users can override the behaviour by setting `tmp_relation_type`.

Also, setting compatibility to dbt-core<1.4 since that version contains breaking changes for us.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [ ] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [ ] I have pulled/merged from the main branch if there are merge conflicts.
- [ ] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
