### PR TITLE
test: Fix type failure on dbt test

### DIFF
--- a/dbt/include/firebolt/macros/materializations/test.sql
+++ b/dbt/include/firebolt/macros/materializations/test.sql
@@ -1,7 +1,7 @@
-{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) %}
+{% macro firebolt__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) %}
 
     SELECT
-      CAST({{ fail_calc }} AS INT) AS failures,
+      COALESCE(CAST({{ fail_calc }} AS INT), 0) AS failures,
       CASE WHEN {{ fail_calc }} {{ warn_if }}
         THEN 'true' ELSE 'false'
       END AS should_warn,


### PR DESCRIPTION
### Description

Type verification fails on null in an INT column. Logically, number of failures if there are no failures should be 0, which this test confirms.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required/relevant for this PR.
- [ ] I have run `changie new` and committed everything in .changes folder
- [ ] I have removed any print or log calls that were added for debugging.
- [ ] I have verified that this PR contains only code changes relevant to this PR.
- [ ] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [ ] I have pulled/merged from the main branch if there are merge conflicts.
- [ ] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
