### PR TITLE
fix: column type resolution

### DIFF
--- a/.changes/unreleased/Fixed-20230426-162250.yaml
+++ b/.changes/unreleased/Fixed-20230426-162250.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Incorrect column resolution when using get_columns_in_relation macro
+time: 2023-04-26T16:22:50.308029+01:00

--- a/dbt/adapters/firebolt/column.py
+++ b/dbt/adapters/firebolt/column.py
@@ -17,4 +17,4 @@ class FireboltColumn(Column):
     def from_description(cls, name: str, raw_data_type: str) -> Column:
         if raw_data_type.startswith('ARRAY'):
             return cls(name, raw_data_type)
-        return Column.from_description(name, raw_data_type)
+        return super().from_description(name, raw_data_type)


### PR DESCRIPTION
### Description

Fixing an error when get_columns_in_relation macro would return types incompatible with Firebolt database. Adding tests to spot those errors in the future.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [ ] I have pulled/merged from the main branch if there are merge conflicts.
- [ ] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
