### PR TITLE
fix: Better error message on schema mismatch

### DIFF
--- a/.changes/unreleased/Fixed-20230504-095842.yaml
+++ b/.changes/unreleased/Fixed-20230504-095842.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Error message on schema mismatch now shows the exact mismatch
+time: 2023-05-04T09:58:42.125493+01:00

--- a/.changes/unreleased/Fixed-20230504-110400.yaml
+++ b/.changes/unreleased/Fixed-20230504-110400.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Refactored deprecated error message parsing
+time: 2023-05-04T11:04:00.263746+01:00

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -90,7 +90,7 @@ class FireboltIndexConfig(dbtClassMixin):
                 )
             return index_config
         except ValidationError as exc:
-            msg = DbtRuntimeError().validator_error_message(exc)
+            msg = DbtRuntimeError('').validator_error_message(exc)
             raise CompilationError(f'Could not parse index config: {msg}.')
         return None
 

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -90,7 +90,7 @@ class FireboltIndexConfig(dbtClassMixin):
                 )
             return index_config
         except ValidationError as exc:
-            msg = DbtRuntimeError.validator_error_message(exc)
+            msg = DbtRuntimeError().validator_error_message(exc)
             raise CompilationError(f'Could not parse index config: {msg}.')
         return None
 

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -14,7 +14,6 @@ from dbt.exceptions import (
     CompilationError,
     DbtRuntimeError,
     NotImplementedError,
-    validator_error_message,
 )
 
 from dbt.adapters.firebolt.column import FireboltColumn
@@ -91,7 +90,7 @@ class FireboltIndexConfig(dbtClassMixin):
                 )
             return index_config
         except ValidationError as exc:
-            msg = validator_error_message(exc)
+            msg = DbtRuntimeError.validator_error_message(exc)
             raise CompilationError(f'Could not parse index config: {msg}.')
         return None
 

--- a/dbt/include/firebolt/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt/include/firebolt/macros/materializations/models/incremental/on_schema_change.sql
@@ -71,11 +71,19 @@
       {% do exceptions.raise_compiler_error(
           'A schema change was detected and `on_schema_change` was set to "fail".') %}
     {% else %}
-      {% do exceptions.raise_compiler_error(
-          'Schema changes detected. Either revert the change or run the model with the ' ~
-          '--full-refresh flag on the command line to recreate the model with the new ' ~
-          'schema definition. Running with the --full-refresh flag drops and recreates ' ~
-          'the database object.') %}
+      {% set fail_msg %}
+          Schema changes detected on this incremental!
+          Either revert the change or run the model with the --full-refresh flag
+          on the command line to recreate the model with the new schema definition.
+          Running with the --full-refresh flag drops and recreates the database object.
+
+          Additional troubleshooting context:
+              Source columns not in target: {{ schema_changes_dict['source_not_in_target'] }}
+              Target columns not in source: {{ schema_changes_dict['target_not_in_source'] }}
+              New column types: {{ schema_changes_dict['new_target_types'] }}
+      {% endset %}
+
+      {% do exceptions.raise_compiler_error(fail_msg) %}
     {% endif %}
   {% endif %}
   {{ return(schema_changes_dict['common_columns']) }}


### PR DESCRIPTION
### Description

This helps debug an issue when schema changes occur. 
Also, fixing a deprecated error message parsing.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [ ] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [ ] I have pulled/merged from the main branch if there are merge conflicts.
- [ ] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
