### PR TITLE
test: prevent secret output

### DIFF
--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -44,25 +44,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]" --no-cache-dir
 
-      - name: Determine env variables
-        run: |
-          if [ "${{ inputs.environment }}" == 'staging' ]; then
-             echo "USERNAME=${{ secrets.FIREBOLT_USERNAME_STAGING }}" >> "$GITHUB_ENV"
-             echo "PASSWORD=${{ secrets.FIREBOLT_PASSWORD_STAGING }}" >> "$GITHUB_ENV"
-          else
-             echo "USERNAME=${{ secrets.FIREBOLT_USERNAME_DEV }}" >> "$GITHUB_ENV"
-             echo "PASSWORD=${{ secrets.FIREBOLT_PASSWORD_DEV }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Keep environment name in the summary
-        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
-
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@v1
+        uses: firebolt-db/integration-testing-setup@master
         with:
-          firebolt-username: ${{ env.USERNAME }}
-          firebolt-password: ${{ env.PASSWORD }}
+          firebolt-username: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_USERNAME || secrets.FIREBOLT_USERNAME_DEV }}
+          firebolt-password: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_PASSWORD || secrets.FIREBOLT_PASSWORD_DEV }}
           api-endpoint: "api.${{ inputs.environment }}.firebolt.io"
           region: "us-east-1"
 
@@ -76,8 +63,8 @@ jobs:
 
       - name: Run integration tests
         env:
-          USER_NAME: ${{ env.USERNAME }}
-          PASSWORD: ${{ env.PASSWORD }}
+          USER_NAME: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_USERNAME || secrets.FIREBOLT_USERNAME_DEV }}
+          PASSWORD: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_PASSWORD || secrets.FIREBOLT_PASSWORD_DEV }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           API_ENDPOINT: "api.${{ inputs.environment }}.firebolt.io"

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@master
+        uses: firebolt-db/integration-testing-setup@v1
         with:
           firebolt-username: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_USERNAME || secrets.FIREBOLT_USERNAME_DEV }}
           firebolt-password: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_PASSWORD || secrets.FIREBOLT_PASSWORD_DEV }}

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -44,6 +44,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]" --no-cache-dir
 
+      - name: Keep environment name in the summary
+        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
+
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find_namespace:
 install_requires =
     dbt-core~=1.5
     firebolt-sdk>=1.1.0
+    pydantic>=0.23
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,31 @@
 import os
 
 import pytest
+from dbt.tests.util import write_file
+from yaml import SafeDumper, dump_all
 
 # Import the standard functional fixtures as a plugin
 # Note: fixtures with session scope need to be local
 pytest_plugins = ['dbt.tests.fixtures.project']
+
+
+class Secret:
+    """
+    Class to hold sensitive data in testing. This prevents passwords
+    and such to be printed in logs or any other reports.
+    More info: https://github.com/pytest-dev/pytest/issues/8613
+    NOTE: be careful, assert Secret('') == '' would still print
+    on failure
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return 'Secret(********)'
+
+    def __str___(self):
+        return '*******'
 
 
 # The profile dictionary, used to write out profiles.yml
@@ -23,10 +44,10 @@ def dbt_profile_target():
     # add credentials to the profile keys
     if os.getenv('USER_NAME') and os.getenv('PASSWORD'):
         profile['user'] = os.getenv('USER_NAME')
-        profile['password'] = os.getenv('PASSWORD')
+        profile['password'] = Secret(os.getenv('PASSWORD'))
     elif os.getenv('CLIENT_ID') and os.getenv('CLIENT_SECRET'):
         profile['client_id'] = os.getenv('CLIENT_ID')
-        profile['client_secret'] = os.getenv('CLIENT_SECRET')
+        profile['client_secret'] = Secret(os.getenv('CLIENT_SECRET'))
     else:
         raise Exception('No credentials found in environment')
     return profile
@@ -53,6 +74,30 @@ def dbt_profile_data(dbt_profile_target, profiles_config_update):
     if profiles_config_update:
         profile.update(profiles_config_update)
     return profile
+
+
+class SafeSecretDumper(SafeDumper):
+    """
+    A custom dumper that will not dump secrets
+    """
+
+    def represent_data(self, data):
+        if isinstance(data, Secret):
+            return self.represent_scalar('tag:yaml.org,2002:str', '********')
+        return super().represent_data(data)
+
+
+@pytest.fixture(scope='class')
+def profiles_yml(profiles_root, dbt_profile_data):
+    """Override dbt fixture to work with Secret class in profiles"""
+    os.environ['DBT_PROFILES_DIR'] = str(profiles_root)
+    write_file(
+        dump_all([dbt_profile_data], Dumper=SafeSecretDumper),
+        profiles_root,
+        'profiles.yml',
+    )
+    yield dbt_profile_data
+    del os.environ['DBT_PROFILES_DIR']
 
 
 @pytest.fixture(scope='class')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,12 +78,12 @@ def dbt_profile_data(dbt_profile_target, profiles_config_update):
 
 class SafeSecretDumper(SafeDumper):
     """
-    A custom dumper that will not dump secrets
+    A custom dumper that understands the Secret class
     """
 
     def represent_data(self, data):
         if isinstance(data, Secret):
-            return self.represent_scalar('tag:yaml.org,2002:str', '********')
+            return self.represent_scalar('tag:yaml.org,2002:str', data.value)
         return super().represent_data(data)
 
 


### PR DESCRIPTION
FIR-29705
Preventing accidental secret output.

Changing staging/dev secrets logic since the old one didn't handle special characters correctly and now we have those with the new credentials. In any case, dev will be retired soon.