### PR TITLE
build: Remove Python 3.7 support

### DIFF
--- a/.changes/unreleased/Removed-20240126-115014.yaml
+++ b/.changes/unreleased/Removed-20240126-115014.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: Removed Python 3.7 support
+time: 2024-01-26T11:50:14.458428Z

--- a/.github/workflows/jaffle-shop-v1.yml
+++ b/.github/workflows/jaffle-shop-v1.yml
@@ -22,10 +22,10 @@ jobs:
           repository: firebolt-db/jaffle_shop_firebolt
           path: jaffle-shop
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/jaffle-shop-v2.yml
+++ b/.github/workflows/jaffle-shop-v2.yml
@@ -22,10 +22,10 @@ jobs:
           repository: firebolt-db/jaffle_shop_firebolt
           path: jaffle-shop
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 project_urls =
@@ -26,7 +25,7 @@ install_requires =
     dbt-core~=1.5
     firebolt-sdk>=1.1.0
     pydantic>=0.23
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 package_dir =
     = .


### PR DESCRIPTION
### Description

Removing 3.7 support as described in DBT 1.6 [guidelines](https://github.com/dbt-labs/dbt-core/discussions/7958).

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
