### PR TITLE
ci: Remove retired dev environment

### DIFF
--- a/.changes/unreleased/Deprecated-20240126-113251.yaml
+++ b/.changes/unreleased/Deprecated-20240126-113251.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: Deprecated dev CI runs
+time: 2024-01-26T11:32:51.732389Z

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -2,29 +2,11 @@ name: Run integration tests V1
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
       FIREBOLT_STG_USERNAME:
         required: true
       FIREBOLT_STG_PASSWORD:
-        required: true
-      FIREBOLT_USERNAME:
-        required: true
-      FIREBOLT_PASSWORD:
         required: true
 
 jobs:
@@ -44,16 +26,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]" --no-cache-dir
 
-      - name: Keep environment name in the summary
-        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
-
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v1
         with:
-          firebolt-username: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_USERNAME || secrets.FIREBOLT_USERNAME_DEV }}
-          firebolt-password: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_PASSWORD || secrets.FIREBOLT_PASSWORD_DEV }}
-          api-endpoint: "api.${{ inputs.environment }}.firebolt.io"
+          firebolt-username: ${{ secrets.FIREBOLT_STG_USERNAME }}
+          firebolt-password: ${{ secrets.FIREBOLT_STG_PASSWORD }}
+          api-endpoint: "api.staging.firebolt.io"
           region: "us-east-1"
 
       - name: Restore cached failed tests
@@ -66,11 +45,11 @@ jobs:
 
       - name: Run integration tests
         env:
-          USER_NAME: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_USERNAME || secrets.FIREBOLT_USERNAME_DEV }}
-          PASSWORD: ${{ inputs.environment == 'staging' && secrets.FIREBOLT_STG_PASSWORD || secrets.FIREBOLT_PASSWORD_DEV }}
+          USER_NAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
+          PASSWORD: ${{ secrets.FIREBOLT_STG_PASSWORD }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          API_ENDPOINT: "api.${{ inputs.environment }}.firebolt.io"
+          API_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |
           pytest --last-failed -o log_cli=true -o log_cli_level=INFO tests/functional/ --alluredir=allure-results

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -2,26 +2,8 @@ name: Run integration tests V2
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
-      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
-        required: true
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
@@ -44,27 +26,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[dev]" --no-cache-dir
 
-      - name: Determine env variables
-        run: |
-          if [ "${{ inputs.environment }}" == 'staging' ]; then
-             echo "CLIENT_ID=${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" >> "$GITHUB_ENV"
-             echo "CLIENT_SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" >> "$GITHUB_ENV"
-          else
-             echo "CLIENT_ID=${{ secrets.FIREBOLT_CLIENT_ID_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
-             echo "CLIENT_SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Keep environment name in the summary
-        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
-
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v2
         with:
-          firebolt-client-id: ${{ env.CLIENT_ID }}
-          firebolt-client-secret: ${{ env.CLIENT_SECRET }}
+          firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           account: "automation"
-          api-endpoint: "api.${{ inputs.environment }}.firebolt.io"
+          api-endpoint: "api.staging.firebolt.io"
 
       - name: Restore cached failed tests
         id: cache-tests-restore
@@ -76,11 +45,11 @@ jobs:
 
       - name: Run integration tests
         env:
-          CLIENT_ID: ${{ env.CLIENT_ID }}
-          CLIENT_SECRET: ${{ env.CLIENT_SECRET }}
+          CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          API_ENDPOINT: "api.${{ inputs.environment }}.firebolt.io"
+          API_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "automation"
         run: |
           pytest --last-failed -o log_cli=true -o log_cli_level=INFO tests/functional/ --alluredir=allure-results

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,33 +2,11 @@ name: Run integration tests
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
       FIREBOLT_STG_USERNAME:
         required: true
       FIREBOLT_STG_PASSWORD:
-        required: true
-      FIREBOLT_USERNAME:
-        required: true
-      FIREBOLT_PASSWORD:
-        required: true
-      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
         required: true
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
@@ -38,11 +16,7 @@ on:
 jobs:
   integration-test-v1:
     uses: ./.github/workflows/integration-tests-v1.yml
-    with:
-      environment: ${{ inputs.environment }}
     secrets: inherit
   integration-test-v2:
     uses: ./.github/workflows/integration-tests-v2.yml
-    with:
-      environment: ${{ inputs.environment }}
     secrets: inherit

--- a/.github/workflows/jaffle-shop-v1.yml
+++ b/.github/workflows/jaffle-shop-v1.yml
@@ -1,25 +1,11 @@
 name: Run Jaffle shop tests V1
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
-      FIREBOLT_USERNAME:
+      FIREBOLT_STG_USERNAME:
         required: true
-      FIREBOLT_PASSWORD:
+      FIREBOLT_STG_PASSWORD:
         required: true
 jobs:
   tests:
@@ -46,35 +32,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install "dbt-firebolt/.[dev]"
 
-      - name: Determine env variables
-        run: |
-          if [ "${{ inputs.environment }}" == 'staging' ]; then
-             echo "USERNAME=${{ secrets.FIREBOLT_USERNAME_STAGING }}" >> "$GITHUB_ENV"
-             echo "PASSWORD=${{ secrets.FIREBOLT_PASSWORD_STAGING }}" >> "$GITHUB_ENV"
-          else
-             echo "USERNAME=${{ secrets.FIREBOLT_USERNAME_DEV }}" >> "$GITHUB_ENV"
-             echo "PASSWORD=${{ secrets.FIREBOLT_PASSWORD_DEV }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Keep environment name in the summary
-        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
-
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v1
         with:
-          firebolt-username: ${{ env.USERNAME }}
-          firebolt-password: ${{ env.PASSWORD }}
-          api-endpoint: "api.${{ inputs.environment }}.firebolt.io"
+          firebolt-username: ${{ secrets.FIREBOLT_STG_USERNAME }}
+          firebolt-password: ${{ secrets.FIREBOLT_STG_PASSWORD }}
+          api-endpoint: "api.staging.firebolt.io"
           region: "us-east-1"
 
       - name: Run Jaffle Shop test workflow
         env:
-          USER_NAME: ${{ env.USERNAME }}
-          PASSWORD: ${{ env.PASSWORD }}
+          USER_NAME: ${{ secrets.FIREBOLT_STG_USERNAME }}
+          PASSWORD: ${{ secrets.FIREBOLT_STG_PASSWORD }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          API_ENDPOINT: "api.${{ inputs.environment }}.firebolt.io"
+          API_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "firebolt"
           DBT_PROFILES_DIR: "../dbt-firebolt/.github/workflows/jaffle_shop"
         working-directory: jaffle-shop

--- a/.github/workflows/jaffle-shop-v2.yml
+++ b/.github/workflows/jaffle-shop-v2.yml
@@ -1,26 +1,8 @@
 name: Run Jaffle shop tests V2
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
-      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
-        required: true
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
@@ -50,40 +32,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install "dbt-firebolt/.[dev]"
 
-      - name: Determine env variables
-        run: |
-          if [ "${{ inputs.environment }}" == 'staging' ]; then
-              echo "KEY=${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" >> "$GITHUB_ENV"
-              echo "SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" >> "$GITHUB_ENV"
-          else
-              echo "KEY=${{ secrets.FIREBOLT_CLIENT_ID_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
-              echo "SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Keep environment name in the summary
-        run: echo '### Ran integration tests against ${{ inputs.environment }} ' >> $GITHUB_STEP_SUMMARY
-
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v2
         with:
-          firebolt-client-id: ${{ env.KEY }}
-          firebolt-client-secret: ${{ env.SECRET }}
+          firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           account: "automation"
-          api-endpoint: "api.${{ inputs.environment }}.firebolt.io"
+          api-endpoint: "api.staging.firebolt.io"
 
 
       - name: Run Jaffle Shop test workflow
         env:
-          USER_NAME: ${{ env.KEY }}
-          PASSWORD: ${{ env.SECRET }}
+          USER_NAME: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+          PASSWORD: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          API_ENDPOINT: "api.${{ inputs.environment }}.firebolt.io"
+          API_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "automation"
           DBT_PROFILES_DIR: "../dbt-firebolt/.github/workflows/jaffle_shop"
         working-directory: jaffle-shop
         run:
           ../dbt-firebolt/.github/workflows/jaffle_shop/run_test_workflow.sh
-
-

--- a/.github/workflows/jaffle_shop.yml
+++ b/.github/workflows/jaffle_shop.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      FIREBOLT_USERNAME_STAGING:
+      FIREBOLT_STG_USERNAME:
         required: true
-      FIREBOLT_PASSWORD_STAGING:
+      FIREBOLT_STG_PASSWORD:
         required: true
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true

--- a/.github/workflows/jaffle_shop.yml
+++ b/.github/workflows/jaffle_shop.yml
@@ -1,33 +1,11 @@
 name: Run Jaffle shop tests
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to run the tests against'
-        type: choice
-        required: true
-        default: 'dev'
-        options:
-          - dev
-          - staging
   workflow_call:
-    inputs:
-      environment:
-        default: 'staging'
-        required: false
-        type: string
     secrets:
       FIREBOLT_USERNAME_STAGING:
         required: true
       FIREBOLT_PASSWORD_STAGING:
-        required: true
-      FIREBOLT_USERNAME_DEV:
-        required: true
-      FIREBOLT_PASSWORD_DEV:
-        required: true
-      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
         required: true
       FIREBOLT_CLIENT_ID_STG_NEW_IDN:
         required: true
@@ -36,11 +14,7 @@ on:
 jobs:
   jaffle-shop-v1:
     uses: ./.github/workflows/jaffle-shop-v1.yml
-    with:
-      environment: ${{ github.event.inputs.environment }}
     secrets: inherit
   jaffle-shop-v2:
     uses: ./.github/workflows/jaffle-shop-v2.yml
-    with:
-      environment: ${{ github.event.inputs.environment }}
     secrets: inherit


### PR DESCRIPTION
FIR-29774

### Description

Dev environment is retired, removing it.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
