### PR TITLE
fix: Whitespace trim to allow comments in CTAS

### DIFF
--- a/.changes/unreleased/Fixed-20240304-112033.yaml
+++ b/.changes/unreleased/Fixed-20240304-112033.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Prevent comments at the end of a model from breaking the SQL
+time: 2024-03-04T11:20:33.150872Z

--- a/dbt/include/firebolt/macros/adapters.sql
+++ b/dbt/include/firebolt/macros/adapters.sql
@@ -239,9 +239,9 @@
   {%- endif  %}
   {%- if not contract_config.enforced %}
     AS (
-  {%- endif -%}
+  {% endif -%}
     {{ select_sql }}
-  {%- if not contract_config.enforced -%}
+  {% if not contract_config.enforced -%}
     )
   {%- endif -%}
 {% endmacro %}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -3,6 +3,12 @@ from dbt.tests.adapter.basic.expected_catalog import (
     expected_references_catalog,
     no_stats,
 )
+from dbt.tests.adapter.basic.files import (
+    base_materialized_var_sql,
+    base_view_sql,
+    config_materialized_table,
+    schema_base_yml,
+)
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_docs_generate import (
@@ -53,7 +59,20 @@ class AnySpecifiedType:
 
 
 class TestSimpleMaterializationsFirebolt(BaseSimpleMaterializations):
-    pass
+    # Adding comment to verify CTAS wrapping
+    # more info in PR #122
+    my_model_base = """
+    select * from {{ source('raw', 'seed') }} -- Some Comment"""
+    my_base_table_sql = config_materialized_table + my_model_base
+
+    @fixture(scope='class')
+    def models(self):
+        return {
+            'view_model.sql': base_view_sql,
+            'table_model.sql': self.my_base_table_sql,
+            'swappable.sql': base_materialized_var_sql,
+            'schema.yml': schema_base_yml,
+        }
 
 
 class TestSingularTestsFirebolt(BaseSingularTests):


### PR DESCRIPTION
### Description

Avoid trimming whitespace after ( and before ) in CTAS.
We had issues when a model would contain a `-- comment` on the last line. With whitespace trimming it would place the whole model query inside `()` brackets, but the closing bracket would be inside a comment and therefore break the SQL.
e.g.
```
SELECT * FROM x -- this is a comment
```
compiles to
```
CREATE TABLE b AS
(SELECT * FROM x -- this is a comment)
```
This change fixes it by making sure there's always a newline after ( and before ).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
