### PR TITLE
test: Skip backslash test

### DIFF
--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -275,6 +275,7 @@ class TestDateTrunc(BaseDateTrunc):
         }
 
 
+@mark.skip('Escaping with backslash is not supported in Firebolt')
 class TestEscapeSingleQuotes(BaseEscapeSingleQuotesBackslash):
     pass
 


### PR DESCRIPTION
Firebolt syntax no longer supports `SELECT 'they\'re' as X` so this test is no longer relevant. This is similar to Postgres dialect, which has a switch that supports this legacy syntax.
In dbt-postgres this test is disabled as well.