### PR TITLE
ci: Add nightly tests

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
-    
+      uses: actions/checkout@v4
+
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/jaffle_shop/run_test_workflow.sh
+++ b/.github/workflows/jaffle_shop/run_test_workflow.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 set -e
 dbt debug
 dbt clean

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,36 +1,40 @@
-name: Run Jaffle shop tests V2
+name: Nightly code check
 on:
   workflow_dispatch:
-  workflow_call:
-    secrets:
-      FIREBOLT_CLIENT_ID_STG_NEW_IDN:
-        required: true
-      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
-        required: true
+  schedule:
+    - cron: '0 1 * * *' # 3 am UTC every day
 jobs:
+  code-check:
+    uses: ./.github/workflows/code-check.yml
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # finish all jobs even if one fails
+      max-parallel: 2
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Check out dbt-adapter code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: dbt-firebolt
 
       - name: Check out Jaffle Shop code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: firebolt-db/jaffle_shop_firebolt
           path: jaffle-shop
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "dbt-firebolt/.[dev]"
+          pip install -e "dbt-firebolt/.[dev]"
 
       - name: Setup database and engine
         id: setup
@@ -40,7 +44,6 @@ jobs:
           firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
           account: ${{ vars.FIREBOLT_ACCOUNT }}
           api-endpoint: "api.staging.firebolt.io"
-
 
       - name: Run Jaffle Shop test workflow
         env:
@@ -52,5 +55,17 @@ jobs:
           ACCOUNT_NAME: ${{ vars.FIREBOLT_ACCOUNT }}
           DBT_PROFILES_DIR: "../dbt-firebolt/.github/workflows/jaffle_shop"
         working-directory: jaffle-shop
-        run:
+        shell: bash
+        run: |
           ../dbt-firebolt/.github/workflows/jaffle_shop/run_test_workflow.sh
+
+      - name: Slack Notify of failure
+        if: failure()
+        id: slack
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ matrix.os }}
+          programming-language: Python
+          language-version: ${{ matrix.python-version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
-    dbt-core~=1.6
+    dbt-core~=1.6,<1.8
     firebolt-sdk>=1.1.0
     pydantic>=0.23
 python_requires = >=3.8


### PR DESCRIPTION
Using Jaffle Shop as running the full test suite that runs for over an hour is not feasible. This gives us a good overview if the main operations supported in DBT are still working on all of those Python versions and OSs.