### PR TITLE
build: limit dbt-core to 1.8

### DIFF
--- a/.changes/unreleased/Changed-20240719-120150.yaml
+++ b/.changes/unreleased/Changed-20240719-120150.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Limit dbt-core to 1.8 to avoid breakage
+time: 2024-07-19T12:01:50.461961+01:00

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
-    dbt-core~=1.6
+    dbt-core~=1.6,<1.8
     firebolt-sdk>=1.1.0
     pydantic>=0.23
 python_requires = >=3.8


### PR DESCRIPTION
### Description

dbt-core 1.8 contains breaking changes to our connector so we need to limit the max version to 1.7.*

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
