### PR TITLE
fix: Whitespace in external table compression

### DIFF
--- a/.changes/unreleased/Fixed-20240726-101135.yaml
+++ b/.changes/unreleased/Fixed-20240726-101135.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Broken whitesace when compression was specified in external tables
+time: 2024-07-26T10:11:35.676767+01:00

--- a/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
@@ -30,6 +30,6 @@
                 {{- ',' if not loop.last }}
             {%- endfor %}
     {%- endif %}
-    {%- if external.compression -%} COMPRESSION = {{external.compression}} {%- endif -%}
+    {%- if external.compression -%} COMPRESSION = {{external.compression}} {%- endif %}
     TYPE = {{ external.type }}
 {% endmacro %}


### PR DESCRIPTION
### Description

Whitespace was being truncated in this sql resulting in malformed query when compression is added.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
