### PR TITLE
test: Skip incompatible tests

### DIFF
--- a/.changes/unreleased/Fixed-20240828-120547.yaml
+++ b/.changes/unreleased/Fixed-20240828-120547.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Incompatible tests
+time: 2024-08-28T12:05:47.794056+01:00

--- a/tests/functional/adapter/test_store_test_failures.py
+++ b/tests/functional/adapter/test_store_test_failures.py
@@ -1,3 +1,5 @@
+import os
+
 from dbt.tests.adapter.store_test_failures_tests.basic import (
     StoreTestFailuresAsExceptions,
     StoreTestFailuresAsGeneric,
@@ -6,29 +8,36 @@ from dbt.tests.adapter.store_test_failures_tests.basic import (
     StoreTestFailuresAsProjectLevelOff,
     StoreTestFailuresAsProjectLevelView,
 )
+from pytest import mark
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsInteractions(StoreTestFailuresAsInteractions):
     pass
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsProjectLevelOff(StoreTestFailuresAsProjectLevelOff):
     pass
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsProjectLevelView(StoreTestFailuresAsProjectLevelView):
     pass
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsGeneric(StoreTestFailuresAsGeneric):
     pass
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsProjectLevelEphemeral(
     StoreTestFailuresAsProjectLevelEphemeral
 ):
     pass
 
 
+@mark.skipif(bool(os.getenv('PASSWORD')), reason='Not supported in FB 1.0')
 class TestStoreTestFailuresAsExceptions(StoreTestFailuresAsExceptions):
     pass


### PR DESCRIPTION
### Description

These tests rely on columns being nullable by default. We'll have to skip them for FB 1.0.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
