### PR TITLE
feat(FIR-35169): dbt 1.8 support

### DIFF
--- a/.changes/unreleased/Added-20240830-134618.yaml
+++ b/.changes/unreleased/Added-20240830-134618.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: dbt 1.8 support
+time: 2024-08-30T13:46:18.709204+01:00

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -5,9 +5,8 @@ from datetime import datetime
 from typing import Any, List, Mapping, Optional, Union
 
 import agate
-from dbt.adapters.base import available  # type: ignore
-from dbt.adapters.base.impl import AdapterConfig  # type: ignore
 from dbt.adapters.base.impl import ConstraintSupport
+from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.capability import (
     Capability,
@@ -15,10 +14,11 @@ from dbt.adapters.capability import (
     CapabilitySupport,
     Support,
 )
-from dbt.adapters.sql import SQLAdapter  # type: ignore
-from dbt.contracts.graph.nodes import ConstraintType
-from dbt.dataclass_schema import ValidationError, dbtClassMixin
-from dbt.exceptions import (
+from dbt.adapters.protocol import AdapterConfig
+from dbt.adapters.sql.impl import SQLAdapter
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.dataclass_schema import ValidationError, dbtClassMixin
+from dbt_common.exceptions import (
     CompilationError,
     DbtRuntimeError,
     NotImplementedError,

--- a/dbt/adapters/firebolt/relation.py
+++ b/dbt/adapters/firebolt/relation.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, Optional
 
-from dbt.adapters.base import RelationType  # type: ignore
-from dbt.adapters.base.relation import BaseRelation, Policy  # type: ignore
-from dbt.adapters.relation_configs import RelationConfigBase  # type: ignore
-from dbt.exceptions import DbtRuntimeError
+from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.contracts.relation import Policy, RelationType
+from dbt.adapters.relation_configs.config_base import RelationConfigBase
+from dbt_common.exceptions import DbtRuntimeError
 
 
 @dataclass

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ project_urls =
 [options]
 packages = find_namespace:
 install_requires =
-    dbt-core~=1.6,<1.8
+    dbt-adapters>=1.0,<2.0
+    dbt-core>=1.8.0
     firebolt-sdk>=1.1.0
     pydantic>=0.23
 python_requires = >=3.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ def dbt_profile_target():
     # add credentials to the profile keys
     if os.getenv('USER_NAME') and os.getenv('PASSWORD'):
         profile['user'] = os.getenv('USER_NAME')
-        profile['password'] = SecretStr(os.getenv('PASSWORD'))
+        profile['password'] = SecretStr(os.getenv('PASSWORD', ''))
     elif os.getenv('CLIENT_ID') and os.getenv('CLIENT_SECRET'):
         profile['client_id'] = os.getenv('CLIENT_ID')
-        profile['client_secret'] = SecretStr(os.getenv('CLIENT_SECRET'))
+        profile['client_secret'] = SecretStr(os.getenv('CLIENT_SECRET', ''))
     else:
         raise Exception('No credentials found in environment')
     return profile

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -183,6 +183,11 @@ class TestDocsGenerateFirebolt(BaseDocsGenerate):
     def unique_schema(request, prefix) -> str:
         return 'public'
 
+    @fixture(autouse=True)
+    def clean_up(self, project):
+        # No schema support so we can't clean up schemas
+        yield
+
     @fixture(scope='class')
     def models(self):
         return {

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+
+
+class TestFireboltEmpty(BaseTestEmpty):
+    pass

--- a/tests/functional/adapter/test_override.py
+++ b/tests/functional/adapter/test_override.py
@@ -1,6 +1,6 @@
 import pytest
-from dbt.exceptions import CompilationError
 from dbt.tests.util import run_dbt
+from dbt_common.exceptions import CompilationError
 
 model_sql = """
 select 1 as id

--- a/tests/functional/adapter/test_query_comment.py
+++ b/tests/functional/adapter/test_query_comment.py
@@ -8,7 +8,6 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseQueryComments,
 )
-from dbt.version import __version__ as dbt_version
 
 
 class TestQueryCommentsFirebolt(BaseQueryComments):
@@ -27,9 +26,9 @@ class TestMacroArgsQueryCommentsFirebolt(BaseMacroArgsQueryComments):
     def test_matches_comment(self, project) -> None:
         logs = self.run_get_json()
         expected_dct = {
-            "app": "dbt++",
-            "macro_version": "0.1.0",
-            "message": f"blah: {project.adapter.config.target_name}",
+            'app': 'dbt++',
+            'macro_version': '0.1.0',
+            'message': f'blah: {project.adapter.config.target_name}',
         }
         expected = '/* {} */'.format(
             json.dumps(expected_dct, sort_keys=True).replace('"', '\\"')

--- a/tests/functional/adapter/test_query_comment.py
+++ b/tests/functional/adapter/test_query_comment.py
@@ -24,13 +24,12 @@ class TestMacroQueryCommentsFirebolt(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryCommentsFirebolt(BaseMacroArgsQueryComments):
-    def test_matches_comment(self, project) -> bool:
+    def test_matches_comment(self, project) -> None:
         logs = self.run_get_json()
         expected_dct = {
-            'app': 'dbt++',
-            'dbt_version': dbt_version,
-            'macro_version': '0.1.0',
-            'message': 'blah: default',
+            "app": "dbt++",
+            "macro_version": "0.1.0",
+            "message": f"blah: {project.adapter.config.target_name}",
         }
         expected = '/* {} */'.format(
             json.dumps(expected_dct, sort_keys=True).replace('"', '\\"')

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -1,0 +1,37 @@
+from dbt.tests.adapter.unit_testing.test_case_insensitivity import (
+    BaseUnitTestCaseInsensivity,
+)
+from dbt.tests.adapter.unit_testing.test_invalid_input import (
+    BaseUnitTestInvalidInput,
+)
+from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
+from pytest import fixture
+
+
+class TestFireboltUnitTestCaseInsensitivity(BaseUnitTestCaseInsensivity):
+    pass
+
+
+class TestFireboltUnitTestInvalidInput(BaseUnitTestInvalidInput):
+    pass
+
+
+class TestFireboltUnitTestingTypes(BaseUnitTestingTypes):
+    @fixture
+    def data_types(self):
+        # sql_value, yaml_value
+        return [
+            ["1", "1"],
+            ["'1'", "1"],
+            ["true", "true"],
+            ["DATE '2020-01-02'", "2020-01-02"],
+            ["TIMESTAMP '2013-11-03 00:00:00'", "2013-11-03 00:00:00"],
+            ["TIMESTAMPTZ '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
+            ["'1'::numeric", "1"],
+            [
+                """'{"bar": "baz", "balance": 7.77, "active": false}'""", # json
+                """'{"bar": "baz", "balance": 7.77, "active": false}'""",
+            ],
+            ["ARRAY['a','b','c']", """'{"a", "b", "c"}'"""],
+            ["ARRAY[1,2,3]", """'{1, 2, 3}'"""],
+        ]

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -21,17 +21,17 @@ class TestFireboltUnitTestingTypes(BaseUnitTestingTypes):
     def data_types(self):
         # sql_value, yaml_value
         return [
-            ["1", "1"],
-            ["'1'", "1"],
-            ["true", "true"],
-            ["DATE '2020-01-02'", "2020-01-02"],
-            ["TIMESTAMP '2013-11-03 00:00:00'", "2013-11-03 00:00:00"],
-            ["TIMESTAMPTZ '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
-            ["'1'::numeric", "1"],
+            ['1', '1'],
+            ["'1'", '1'],
+            ['true', 'true'],
+            ["DATE '2020-01-02'", '2020-01-02'],
+            ["TIMESTAMP '2013-11-03 00:00:00'", '2013-11-03 00:00:00'],
+            ["TIMESTAMPTZ '2013-11-03 00:00:00-0'", '2013-11-03 00:00:00-0'],
+            ["'1'::numeric", '1'],
             [
-                """'{"bar": "baz", "balance": 7.77, "active": false}'""", # json
+                """'{"bar": "baz", "balance": 7.77, "active": false}'""",  # json
                 """'{"bar": "baz", "balance": 7.77, "active": false}'""",
             ],
             ["ARRAY['a','b','c']", """'{"a", "b", "c"}'"""],
-            ["ARRAY[1,2,3]", """'{1, 2, 3}'"""],
+            ['ARRAY[1,2,3]', """'{1, 2, 3}'"""],
         ]

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -1,4 +1,9 @@
 import pytest
+from dbt.tests.adapter.utils import (
+    fixture_array_append,
+    fixture_array_concat,
+    fixture_array_construct,
+)
 from dbt.tests.adapter.utils.fixture_bool_or import (
     models__test_bool_or_sql,
     models__test_bool_or_yml,
@@ -51,21 +56,9 @@ from dbt.tests.adapter.utils.fixture_split_part import (
     models__test_split_part_yml,
 )
 from dbt.tests.adapter.utils.test_any_value import BaseAnyValue
-from dbt.tests.adapter.utils.test_array_append import (
-    BaseArrayAppend,
-    models__array_append_actual_sql,
-    models__array_append_expected_sql,
-)
-from dbt.tests.adapter.utils.test_array_concat import (
-    BaseArrayConcat,
-    models__array_concat_actual_sql,
-    models__array_concat_expected_sql,
-)
-from dbt.tests.adapter.utils.test_array_construct import (
-    BaseArrayConstruct,
-    models__array_construct_actual_sql,
-    models__array_construct_expected_sql,
-)
+from dbt.tests.adapter.utils.test_array_append import BaseArrayAppend
+from dbt.tests.adapter.utils.test_array_concat import BaseArrayConcat
+from dbt.tests.adapter.utils.test_array_construct import BaseArrayConstruct
 from dbt.tests.adapter.utils.test_bool_or import BaseBoolOr
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
 from dbt.tests.adapter.utils.test_concat import BaseConcat
@@ -479,9 +472,9 @@ class TestArrayAppend(BaseArrayAppend):
     def models(self):
         return {
             'actual.yml': schema_actual_table_yml,
-            'actual.sql': models__array_append_actual_sql,
+            'actual.sql': fixture_array_append.models__array_append_actual_sql,
             'expected.yml': schema_expected_table_yml,
-            'expected.sql': models__array_append_expected_sql,
+            'expected.sql': fixture_array_append.models__array_append_expected_sql,
         }
 
 
@@ -491,9 +484,9 @@ class TestArrayConcat(BaseArrayConcat):
     def models(self):
         return {
             'actual.yml': schema_actual_table_yml,
-            'actual.sql': models__array_concat_actual_sql,
+            'actual.sql': fixture_array_concat.models__array_concat_actual_sql,
             'expected.yml': schema_expected_table_yml,
-            'expected.sql': models__array_concat_expected_sql,
+            'expected.sql': fixture_array_concat.models__array_concat_expected_sql,
         }
 
 
@@ -502,9 +495,9 @@ class TestArrayConstruct(BaseArrayConstruct):
     def models(self):
         return {
             'actual.yml': schema_actual_table_yml,
-            'actual.sql': models__array_construct_actual_sql,
+            'actual.sql': fixture_array_construct.models__array_construct_actual_sql,
             'expected.yml': schema_expected_table_yml,
-            'expected.sql': models__array_construct_expected_sql,
+            'expected.sql': fixture_array_construct.models__array_construct_expected_sql,
         }
 
 

--- a/tests/unit/test_firebolt_adapter.py
+++ b/tests/unit/test_firebolt_adapter.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from multiprocessing import get_context
 from unittest.mock import MagicMock, patch
 
-from dbt.contracts.connection import Connection
+from dbt.adapters.contracts.connection import Connection
 from firebolt.client.auth import ClientCredentials, UsernamePassword
 from firebolt.db import ARRAY, DECIMAL
 from firebolt.db.connection import Connection as SDKConnection
@@ -15,6 +16,7 @@ from dbt.adapters.firebolt import (
 )
 from dbt.adapters.firebolt.column import FireboltColumn
 from dbt.adapters.firebolt.connections import _determine_auth
+from tests.functional.adapter.test_basic import AnySpecifiedType
 
 
 @fixture
@@ -54,7 +56,7 @@ def test_open(connection):
 
 @fixture(scope='module')
 def adapter():
-    return FireboltAdapter(MagicMock())
+    return FireboltAdapter(MagicMock(), get_context("spawn"))
 
 
 @mark.parametrize(
@@ -104,7 +106,7 @@ def test_data_type_code_to_name(input_type, expected_output):
     ],
 )
 def test_setting_append(profile, expected):
-    adapter = FireboltAdapter(profile)
+    adapter = FireboltAdapter(profile, get_context("spawn"))
     assert adapter.config.query_comment.append == expected
 
 
@@ -114,7 +116,7 @@ def test_setting_append(profile, expected):
         ('STRING', 'TEXT'),
         ('TIMESTAMP', 'TIMESTAMP'),
         ('FLOAT', 'FLOAT'),
-        ('INTEGER', 'INT'),
+        ('INTEGER', AnySpecifiedType(['INT', 'INTEGER'])),
         ('BOOLEAN', 'BOOLEAN'),
         ('DUMMY_TYPE', 'DUMMY_TYPE'),
         ('TEXT', 'TEXT'),

--- a/tests/unit/test_firebolt_adapter.py
+++ b/tests/unit/test_firebolt_adapter.py
@@ -56,7 +56,7 @@ def test_open(connection):
 
 @fixture(scope='module')
 def adapter():
-    return FireboltAdapter(MagicMock(), get_context("spawn"))
+    return FireboltAdapter(MagicMock(), get_context('spawn'))
 
 
 @mark.parametrize(
@@ -106,7 +106,7 @@ def test_data_type_code_to_name(input_type, expected_output):
     ],
 )
 def test_setting_append(profile, expected):
-    adapter = FireboltAdapter(profile, get_context("spawn"))
+    adapter = FireboltAdapter(profile, get_context('spawn'))
     assert adapter.config.query_comment.append == expected
 
 

--- a/tests/unit/test_firebolt_conversions.py
+++ b/tests/unit/test_firebolt_conversions.py
@@ -2,7 +2,7 @@ import string
 from typing import List
 
 import agate
-from dbt.clients import agate_helper
+from dbt_common.clients import agate_helper
 
 from dbt.adapters.firebolt import FireboltAdapter
 


### PR DESCRIPTION
Resolves #124 

### Description

DBT 1.8 support with refactors required and new tests. Some imports have changed as well as interfaces.
We no longer need to pin the dbt-core version,  but need to make sure dbt-adapters module is included.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
