### PR TITLE
build: Set lower limit of the sdk to 1.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find_namespace:
 install_requires =
     dbt-adapters>=1.0,<2.0
     dbt-core>=1.8.0
-    firebolt-sdk>=1.1.0
+    firebolt-sdk>=1.5.0
     pydantic>=0.23
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
### Description

Features like engine autostart are not available in the versions before. 

