### PR TITLE
feat(FIR-36122): Support host parameter as an alias

### DIFF
--- a/.changes/unreleased/Added-20240902-150119.yaml
+++ b/.changes/unreleased/Added-20240902-150119.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added host connection parameter alias
+time: 2024-09-02T15:01:19.289961+01:00

--- a/dbt/adapters/firebolt/connections.py
+++ b/dbt/adapters/firebolt/connections.py
@@ -44,6 +44,10 @@ class FireboltCredentials(Credentials):
     account_name: Optional[str] = None
     retries: int = 1
 
+    _ALIASES = {
+        'host': 'api_endpoint',
+    }
+
     def __post_init__(self) -> None:
         # If user and password are not provided, assume client_id and client_secret
         # are provided instead


### PR DESCRIPTION
### Description

host parameter is used in some of the connectors instead of api_endpoint. We should support it as a part of the standard set of dbt connection parameters. Adding alias for this.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
