### PR TITLE
fix(FIR-36373): Incremental partition drop

### DIFF
--- a/.changes/unreleased/Fixed-20240904-150720.yaml
+++ b/.changes/unreleased/Fixed-20240904-150720.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Partition drop logic using the old SQL format.
+time: 2024-09-04T15:07:20.500532+01:00

--- a/.github/workflows/jaffle_shop/run_test_workflow.sh
+++ b/.github/workflows/jaffle_shop/run_test_workflow.sh
@@ -17,6 +17,8 @@ fi
 dbt seed
 dbt seed --full-refresh
 dbt run
+# Trigger incremental check
+dbt run
 dbt source freshness
 dbt test
 dbt docs generate

--- a/.github/workflows/jaffle_shop/run_test_workflow.sh
+++ b/.github/workflows/jaffle_shop/run_test_workflow.sh
@@ -17,8 +17,8 @@ fi
 dbt seed
 dbt seed --full-refresh
 dbt run
-# Trigger incremental check
-dbt run
 dbt source freshness
 dbt test
+# Trigger incremental check
+dbt run
 dbt docs generate

--- a/dbt/include/firebolt/macros/materializations/models/incremental/strategies.sql
+++ b/dbt/include/firebolt/macros/materializations/models/incremental/strategies.sql
@@ -64,7 +64,7 @@
 
       SELECT
       {% if partition_cols is iterable and partition_cols is not string -%}
-        DISTINCT({{ partition_cols | join(', ') }})
+        DISTINCT {{ partition_cols | join(', ') }}
       {%- else -%}
         DISTINCT {{ partition_cols }}
       {%- endif %}
@@ -110,7 +110,7 @@
                 of extra work. -#}
             '{{ vals | join(', ') }}'
           {%- else -%}
-            {{ vals | join(', ') }}
+            '{{ vals | join("', '") }}'
           {%- endif -%}
         {%- endif -%}
       {%- else -%}


### PR DESCRIPTION
### Description

insert_overwrite stategy used old synatx for detecting partitions. Updating the syntax not to use tuples (unsupported in Firebolt for now) and making sure the resulting columns are quoted.
Adding a test that checks that rerun worked.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
