### PR TITLE
chore(FIR-34713): Add missing classifiers to setup.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,11 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v2.5.0
     hooks:
       - id: setup-cfg-fmt
+        args:
+          - --include-version-classifiers
 
   - repo: https://github.com/myint/autoflake
     rev: v1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/firebolt-db/dbt-firebolt
 author = Firebolt
 author_email = support@firebolt.io
 license = Apache-2.0
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
@@ -43,7 +43,7 @@ dev =
     allure-pytest==2.*
     dbt-tests-adapter~=1.6
     mypy==1.4.1
-    pre-commit==2.15.0
+    pre-commit==3.8.0
     pytest==7.*
 
 [black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 project_urls =
     Bug Tracker = https://github.com/firebolt-db/dbt-firebolt/issues
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ dev =
     allure-pytest==2.*
     dbt-tests-adapter~=1.6
     mypy==1.4.1
-    pre-commit==3.8.0
+    pre-commit==3.5.0
     pytest==7.*
 
 [black]


### PR DESCRIPTION
### Description

Add classifiers to setup.cfg denoting support for Python 3.8 - 3.12. 
Also fixing pre-commit that would otherwise erase the changes.
