### PR TITLE
test(FIR-35179): re-enable some of the fixed tests

### DIFF
--- a/.changes/unreleased/Changed-20240909-160913.yaml
+++ b/.changes/unreleased/Changed-20240909-160913.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Enabled tests that were disabled due to the feature gaps
+time: 2024-09-09T16:09:13.607541+01:00

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -157,7 +157,6 @@ class TestSnapshotTimestampFirebolt(BaseSnapshotTimestamp):
     pass
 
 
-@mark.skip('Firebolt has a bug in LEFT JOIN. FIR-11078')
 class TestBaseAdapterMethod(BaseAdapterMethod):
     pass
 

--- a/tests/functional/adapter/utils/test_data_types.py
+++ b/tests/functional/adapter/utils/test_data_types.py
@@ -114,7 +114,6 @@ class TestTypeTimestamp(BaseTypeTimestamp):
         }
 
 
-@pytest.mark.skip('True boolean is feature-flagged')
 class TestTypeBoolean(BaseTypeBoolean):
     @pytest.fixture(scope='class')
     def models(self):

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -280,12 +280,12 @@ class TestDateTrunc(BaseDateTrunc):
         }
 
 
-@mark.skip('Escaping with backslash is not supported in Firebolt')
+@mark.skip('Escaping with backslash is not supported by default in Firebolt')
 class TestEscapeSingleQuotes(BaseEscapeSingleQuotesBackslash):
     pass
 
 
-@mark.skip('Except is not supported yet')
+@mark.skip('Except is not supported yet. FIR-16223')
 class TestExcept(BaseExcept):
     pass
 
@@ -313,7 +313,7 @@ class TestHash(BaseHash):
         }
 
 
-@mark.skip('Intersect is not supported yet')
+@mark.skip('Intersect is not supported yet. FIR-16223')
 class TestIntersect(BaseIntersect):
     pass
 


### PR DESCRIPTION
### Description

Some of the skipped tests can now be enabled as the syntax to run them is now supported. Added ticket numbers to others.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
