### PR TITLE
fix(FIR-36503): Remove incorrect syntax in COPY logic

### DIFF
--- a/.changes/unreleased/Fixed-20240910-171459.yaml
+++ b/.changes/unreleased/Fixed-20240910-171459.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Fixed default arguments for copy stategy when they would appear empty when not
+  specified.
+time: 2024-09-10T17:14:59.352269+01:00

--- a/.github/workflows/jaffle_shop/sources_external_tables_copy.yml
+++ b/.github/workflows/jaffle_shop/sources_external_tables_copy.yml
@@ -14,7 +14,6 @@ sources:
             object_pattern: '*raw_customers.csv'
             type: CSV
             auto_create: true
-            allow_column_mismatch: false
             max_errors_per_file: 10
             csv_options:
               header: true

--- a/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
+++ b/dbt/include/firebolt/macros/dbt_external_tables/create_external_table.sql
@@ -68,8 +68,8 @@
     (
         {%- for column in columns -%}
           {{ column.name }}
-          {%- if column.default is not none %} DEFAULT {{ column.default }}{% endif %}
-          {%- if column.source_column_name is not none %} {{ '$' ~ loop.index0 }}{% endif %}
+          {%- if column.default %} DEFAULT {{ column.default }}{% endif %}
+          {%- if column.source_column_name %} {{ '$' ~ loop.index0 }}{% endif %}
           {{- ',' if not loop.last }}
         {%- endfor -%}
     )
@@ -83,10 +83,10 @@
         {%- if options.type %}
             TYPE = {{ options.type }}
         {%- endif %}
-        {%- if options.auto_create is not none %}
+        {%- if options.auto_create %}
             AUTO_CREATE = {{ options.auto_create | upper }}
         {%- endif %}
-        {%- if options.allow_column_mismatch is not none %}
+        {%- if options.allow_column_mismatch %}
             ALLOW_COLUMN_MISMATCH = {{ options.allow_column_mismatch | upper }}
         {%- endif %}
         {%- if options.error_file %}
@@ -99,7 +99,7 @@
             MAX_ERRORS_PER_FILE = {{ options.max_errors_per_file }}
         {%- endif %}
         {%- if csv_options %}
-            {%- if csv_options.header is not none %}
+            {%- if csv_options.header %}
                 HEADER = {{ csv_options.header | upper }}
             {%- endif %}
             {%- if csv_options.delimiter %}
@@ -117,10 +117,10 @@
             {%- if csv_options.null_string %}
                 NULL_STRING = '{{ csv_options.null_string }}'
             {%- endif %}
-            {%- if csv_options.empty_field_as_null is not none %}
+            {%- if csv_options.empty_field_as_null %}
                 EMPTY_FIELD_AS_NULL = {{ csv_options.empty_field_as_null | upper }}
             {%- endif %}
-            {%- if csv_options.skip_blank_lines is not none %}
+            {%- if csv_options.skip_blank_lines %}
                 SKIP_BLANK_LINES = {{ csv_options.skip_blank_lines | upper }}
             {%- endif %}
             {%- if csv_options.date_format %}


### PR DESCRIPTION
### Description

Some arguments had incorrect nullability check. This led to broken SQL when nothing was specified for those arguments.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
