### PR TITLE
feat(FIR-10764): Snapshot support

### DIFF
--- a/.changes/unreleased/Added-20240912-162707.yaml
+++ b/.changes/unreleased/Added-20240912-162707.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Snapshot support
+time: 2024-09-12T16:27:07.67185+01:00

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The table below shows which dbt and Firebolt features are supported by the adapt
 | Incremental materializations - insert_overwrite | :white_check_mark: |
 | Incremental materializations - delete+insert | :white_check_mark: |
 | Incremental materializations - merge | :x: |
-| Snapshots                    | :x: |
+| Snapshots                    | :white_check_mark: |
 | Seeds                        | :white_check_mark: |
 | Tests                        | :white_check_mark: |
 | Documentation                | :white_check_mark: |

--- a/dbt/include/firebolt/macros/materializations/snapshot_merge.sql
+++ b/dbt/include/firebolt/macros/materializations/snapshot_merge.sql
@@ -1,0 +1,19 @@
+{% macro firebolt__snapshot_merge_sql(target, source, insert_cols) -%}
+    {%- set insert_cols_csv = insert_cols | join(', ') -%}
+
+    UPDATE {{ target.render() }} AS DBT_INTERNAL_DEST
+    SET dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+    FROM {{ source }} AS DBT_INTERNAL_SOURCE
+    WHERE DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
+    AND DBT_INTERNAL_DEST.dbt_valid_to IS NULL
+    AND DBT_INTERNAL_SOURCE.dbt_change_type IN ('update', 'delete');
+
+    INSERT INTO {{ target.render() }} ({{ insert_cols_csv }})
+    SELECT {{ insert_cols_csv }}
+    FROM {{ source }} AS DBT_INTERNAL_SOURCE
+    WHERE DBT_INTERNAL_SOURCE.dbt_scd_id NOT IN (
+        SELECT dbt_scd_id FROM {{ target.render() }}
+    )
+    AND DBT_INTERNAL_SOURCE.dbt_change_type = 'insert';
+
+{% endmacro %}

--- a/dbt/include/firebolt/macros/relations/table/create.sql
+++ b/dbt/include/firebolt/macros/relations/table/create.sql
@@ -24,6 +24,10 @@
         ) }}
     {%- endif -%}
 
+    {%- if temporary -%}
+        {%- do adapter.drop_relation(relation) -%}
+    {%- endif -%}
+
     {%- set table_type = config.get(
         'table_type',
         default = 'dimension'

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -147,12 +147,10 @@ class TestGenericTestsFirebolt(BaseGenericTests):
     pass
 
 
-@mark.skip('Not implemented for v1')
 class TestSnapshotCheckColsFirebolt(BaseSnapshotCheckCols):
     pass
 
 
-@mark.skip('Not implemented for v1')
 class TestSnapshotTimestampFirebolt(BaseSnapshotTimestamp):
     pass
 


### PR DESCRIPTION
### Description

This change allows us to use DBT's Snapshot feature. We've been previously blocked by two things: `MERGE` query and `CREATE OR REPLACE TABLE`. Former was rewritten for the snapshotting purpose with INSERT and UPDATE queries. The  latter was achieved the same way as in [table materialisation](https://github.com/firebolt-db/dbt-firebolt/blob/674e35627b6e762a262cf1d067bf9149b1e6794a/dbt/include/firebolt/macros/materializations/table.sql#L25) (which snapshot does not go through).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
