### PR TITLE
fix(FIR-12466): Allow indexes on columns with spaces

### DIFF
--- a/.changes/unreleased/Fixed-20240912-171349.yaml
+++ b/.changes/unreleased/Fixed-20240912-171349.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed an issue when indexes would break on columns containing spaces
+time: 2024-09-12T17:13:49.62438+01:00

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -32,6 +32,7 @@ from dbt.adapters.firebolt.relation import FireboltRelation
 @dataclass
 class FireboltIndexConfig(dbtClassMixin):
     index_type: str
+    index_name: Optional[str] = None
     join_columns: Optional[Union[str, List[str]]] = None
     key_columns: Optional[Union[str, List[str]]] = None
     dimension_column: Optional[Union[str, List[str]]] = None
@@ -43,6 +44,8 @@ class FireboltIndexConfig(dbtClassMixin):
         index type, relation name, key/join columns, timestamp (unix & UTC)
         example index name: join_my_model_customer_id_1633504263.
         """
+        if self.index_name:
+            return self.index_name
         now_unix = str(int(time.mktime(datetime.utcnow().timetuple())))
         # If column_names is a list with > 1 members, join with _,
         # otherwise do not. We were getting index names like

--- a/dbt/adapters/firebolt/impl.py
+++ b/dbt/adapters/firebolt/impl.py
@@ -31,9 +31,13 @@ from dbt.adapters.firebolt.relation import FireboltRelation
 def quote_columns(columns: Union[str, List[str]]) -> Union[str, List[str]]:
     if isinstance(columns, str):
         return f'"{columns}"'
-    return [
-        f'"{col}"' for col in columns if not (col.startswith('"') and col.endswith('"'))
-    ]
+    quoted_columns = []
+    for col in columns:
+        if col.startswith('"') and col.endswith('"'):
+            quoted_columns.append(col)
+        else:
+            quoted_columns.append(f'"{col}"')
+    return quoted_columns
 
 
 @dataclass

--- a/dbt/include/firebolt/macros/relations/table/create.sql
+++ b/dbt/include/firebolt/macros/relations/table/create.sql
@@ -49,9 +49,9 @@
 
     {%- if primary_index %}
         primary INDEX {% if primary_index is iterable and primary_index is not string %}
-            {{ primary_index | join(', ') }}
+            "{{ primary_index | join('", "') }}"
         {%- else -%}
-            {{ primary_index }}
+            "{{ primary_index }}"
         {%- endif -%}
     {%- endif -%}
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -2,7 +2,6 @@ import pytest
 from dbt.adapters.contracts.relation import Path
 
 from dbt.adapters.firebolt.impl import (
-    FireboltAdapter,
     FireboltConfig,
     FireboltIndexConfig,
     FireboltRelation,
@@ -89,11 +88,3 @@ def test_firebolt_config():
         ]
     )
     assert len(config.indexes) == 2
-
-
-def test_firebolt_adapter_is_cancelable():
-    assert not FireboltAdapter.is_cancelable()
-
-
-def test_firebolt_adapter_date_function():
-    assert FireboltAdapter.date_function() == 'now()'

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,0 +1,99 @@
+import pytest
+from dbt.adapters.contracts.relation import Path
+
+from dbt.adapters.firebolt.impl import (
+    FireboltAdapter,
+    FireboltConfig,
+    FireboltIndexConfig,
+    FireboltRelation,
+    quote_columns,
+)
+
+
+@pytest.mark.parametrize(
+    'column, expected',
+    [
+        ('column', '"column"'),
+        (['column1', 'column2'], ['"column1"', '"column2"']),
+        (['"column1"', '"column2"'], ['"column1"', '"column2"']),
+        (['column 1', 'column 2'], ['"column 1"', '"column 2"']),
+    ],
+)
+def test_quote_columns(column, expected):
+    assert quote_columns(column) == expected
+
+
+def test_firebolt_index_config_render_name():
+    relation = FireboltRelation(
+        path=Path(database='my_database', schema='my_schema', identifier='my_model')
+    )
+    index_config = FireboltIndexConfig(
+        index_type='join',
+        join_columns=['column1', 'column2'],
+        dimension_column='dimension',
+    )
+    assert index_config.render_name(relation).startswith(
+        'join_idx__my_model__column1_column2'
+    )
+
+
+def test_firebolt_index_config_render_name_with_special_characters():
+    relation = FireboltRelation(
+        path=Path(database='my_database', schema='my_schema', identifier='my_model')
+    )
+    index_config = FireboltIndexConfig(
+        index_type='join',
+        join_columns=['"column 1"', '"column2"'],
+        dimension_column='dimension',
+    )
+    assert index_config.render_name(relation).startswith(
+        'join_idx__my_model__column_1_column2'
+    )
+
+
+def test_firebolt_index_config_render_with_long_name():
+    relation = FireboltRelation(
+        path=Path(database='my_database', schema='my_schema', identifier='my_model')
+    )
+    index_config = FireboltIndexConfig(
+        index_type='join', join_columns=['column1'] * 50, dimension_column='dimension'
+    )
+    assert len(index_config.render_name(relation)) < 255
+
+
+def test_firebolt_index_config_parse():
+    raw_index = {
+        'index_type': 'join',
+        'join_columns': ['column1', 'column2'],
+        'dimension_column': 'dimension',
+    }
+    index_config = FireboltIndexConfig.parse(raw_index)
+    assert index_config.index_type == 'join'
+    assert index_config.join_columns == ['"column1"', '"column2"']
+    assert index_config.dimension_column == '"dimension"'
+
+
+def test_firebolt_config():
+    config = FireboltConfig(
+        indexes=[
+            FireboltIndexConfig(
+                index_type='join',
+                join_columns=['column1', 'column2'],
+                dimension_column='dimension',
+            ),
+            FireboltIndexConfig(
+                index_type='aggregating',
+                key_columns=['key1', 'key2'],
+                aggregation='aggregation',
+            ),
+        ]
+    )
+    assert len(config.indexes) == 2
+
+
+def test_firebolt_adapter_is_cancelable():
+    assert not FireboltAdapter.is_cancelable()
+
+
+def test_firebolt_adapter_date_function():
+    assert FireboltAdapter.date_function() == 'now()'


### PR DESCRIPTION
### Description

Our index creation logic would break if columns constituting this index had spaces. Adding more advanced logic on index name creation as well as ability to override index name in config.
Also adding a failsafe if index is too long for Firebolt to handle - use the hash instead of failing.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
