### PR TITLE
chore(FIR-42592): Update sdk dependency

### DIFF
--- a/.changes/unreleased/Changed-20250115-162017.yaml
+++ b/.changes/unreleased/Changed-20250115-162017.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Updated minimal sdk version to 1.8.1
+time: 2025-01-15T16:20:17.525517Z

--- a/dbt/adapters/firebolt/connections.py
+++ b/dbt/adapters/firebolt/connections.py
@@ -20,8 +20,7 @@ from dbt_common.exceptions import (
 )
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth, ClientCredentials, UsernamePassword
-from firebolt.common._types import ExtendedType
-from firebolt.db import ARRAY, DECIMAL
+from firebolt.db import ARRAY, DECIMAL, ExtendedType
 from firebolt.db import connect as sdk_connect
 from firebolt.db.connection import Connection as SDKConnection
 from firebolt.db.cursor import Cursor

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find_namespace:
 install_requires =
     dbt-adapters>=1.0,<2.0
     dbt-core>=1.8.0
-    firebolt-sdk>=1.5.0
+    firebolt-sdk>=1.8.1
     pydantic>=0.23
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
This makes sure we won't run into issues with outdated sdk version now that we're using ExtendedType.