### PR TITLE
fix(FIR-46528): dbt_project.yml not found

### DIFF
--- a/.changes/unreleased/Fixed-20250529-103401.yaml
+++ b/.changes/unreleased/Fixed-20250529-103401.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed installation issues when dbt_project.yml is missing
+time: 2025-05-29T10:34:01.38528+01:00

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -23,4 +23,4 @@ jobs:
         python -m pip install ".[dev]"
 
     - name: Run pre-commit checks
-      uses: pre-commit/action@v2.0.3
+      run: pre-commit run --all-files

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,11 @@ dev =
     pre-commit==3.5.0
     pytest==7.*
 
+[options.package_data]
+dbt.include.firebolt =
+    dbt_project.yml
+    macros/*.sql
+
 [black]
 python-version = 3.9
 


### PR DESCRIPTION
### Description

When installing dbt-firebolt with dbt-core 1.9 and up some of the files are not installed in the correct directory. This leads to dbt run failing with 
```
18:02:37  Encountered an error:
Runtime Error
  Failed to read package: Runtime Error
    No dbt_project.yml found at expected path /dbt/dbt-1.9-latest/lib/python3.11/site-packages/dbt/include/firebolt/dbt_project.yml
    Verify that each entry within packages.yml (and their transitive dependencies) contains a file named dbt_project.yml
```

Adding a fix that ensures the files are always included explicitly.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
