### PR TITLE
fix: Include all macros from dbt adapter

### DIFF
--- a/.changes/unreleased/Fixed-20250603-163645.yaml
+++ b/.changes/unreleased/Fixed-20250603-163645.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed package install that was missing several macros from subdirectories.
+time: 2025-06-03T16:36:45.656745+01:00

--- a/.github/workflows/jaffle-shop-v1.yml
+++ b/.github/workflows/jaffle-shop-v1.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           cd dbt-firebolt
-          python -m pip install dbt-core -e .
+          python -m pip install dbt-core .
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/jaffle-shop-v2.yml
+++ b/.github/workflows/jaffle-shop-v2.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           cd dbt-firebolt
-          python -m pip install dbt-core -e .
+          python -m pip install dbt-core .
 
       - name: Setup database and engine
         id: setup

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ dev =
 [options.package_data]
 dbt.include.firebolt =
     dbt_project.yml
-    macros/*.sql
+    macros/**/*.sql
 
 [black]
 python-version = 3.9


### PR DESCRIPTION
### Description

Previous fix was not including macros that were in subdirectories.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
