### PR TITLE
test(NoTicket): fix FB 1.0 tests

### DIFF
--- a/.changes/unreleased/Fixed-20250801-104442.yaml
+++ b/.changes/unreleased/Fixed-20250801-104442.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 1.0 tests that were writing null value into a non-null column
+time: 2025-08-01T10:44:42.192585+01:00

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,14 @@ def is_firebolt_core(dbt_profile_target: dict[str, Any]) -> bool:
 
 
 @pytest.fixture(scope='class')
+def is_firebolt_1_0(dbt_profile_target: dict[str, Any]) -> bool:
+    """
+    Returns True if the connection is to Firebolt 1.0, False otherwise.
+    """
+    return dbt_profile_target.get('password') is not None
+
+
+@pytest.fixture(scope='class')
 def unique_schema(request, prefix) -> str:
     """Firebolt does not have concept of schemas so we return 'public' here."""
     return 'public'

--- a/tests/functional/adapter/incremental/test_incremental.py
+++ b/tests/functional/adapter/incremental/test_incremental.py
@@ -3,6 +3,18 @@ from dbt.tests.adapter.incremental.test_incremental_predicates import (
 )
 from dbt.tests.adapter.incremental.test_incremental_unique_id import (
     BaseIncrementalUniqueKey,
+    models__duplicated_unary_unique_key_list_sql,
+    models__empty_str_unique_key_sql,
+    models__empty_unique_key_list_sql,
+    models__expected__one_str__overwrite_sql,
+    models__expected__unique_key_list__inplace_overwrite_sql,
+    models__no_unique_key_sql,
+    models__nontyped_trinary_unique_key_list_sql,
+    models__not_found_unique_key_list_sql,
+    models__not_found_unique_key_sql,
+    models__str_unique_key_sql,
+    models__trinary_unique_key_list_sql,
+    models__unary_unique_key_list_sql,
 )
 from pytest import fixture, mark
 
@@ -23,7 +35,45 @@ class TestIncrementalUniqueKeyFirebolt(BaseIncrementalUniqueKey):
     pass
 
 
+schema_seed_delete_insert_yml = """
+version: 2
+seeds:
+  - name: seed
+    config:
+      column_types:
+        state: TEXT
+        county: TEXT
+        city: TEXT NULL
+        last_visit_date: TIMESTAMP
+"""
+
+
 class TestUniqueKeyDeleteInsertFirebolt(BaseIncrementalUniqueKey):
     @fixture(scope='class')
     def project_config_update(self):
         return {'models': {'+incremental_strategy': 'delete+insert'}}
+
+    @fixture(scope='class')
+    def models(self, is_firebolt_1_0: bool) -> dict[str, str]:
+        """
+        Override models in order to set seeds nullability for Firebolt 1.0.
+        """
+        model_dict = {
+            'trinary_unique_key_list.sql': models__trinary_unique_key_list_sql,
+            'nontyped_trinary_unique_key_list.sql': models__nontyped_trinary_unique_key_list_sql,  # noqa: E501
+            'unary_unique_key_list.sql': models__unary_unique_key_list_sql,
+            'not_found_unique_key.sql': models__not_found_unique_key_sql,
+            'empty_unique_key_list.sql': models__empty_unique_key_list_sql,
+            'no_unique_key.sql': models__no_unique_key_sql,
+            'empty_str_unique_key.sql': models__empty_str_unique_key_sql,
+            'str_unique_key.sql': models__str_unique_key_sql,
+            'duplicated_unary_unique_key_list.sql': models__duplicated_unary_unique_key_list_sql,  # noqa: E501
+            'not_found_unique_key_list.sql': models__not_found_unique_key_list_sql,
+            'expected': {
+                'one_str__overwrite.sql': models__expected__one_str__overwrite_sql,
+                'unique_key_list__inplace_overwrite.sql': models__expected__unique_key_list__inplace_overwrite_sql,  # noqa: E501
+            },
+        }
+        if is_firebolt_1_0:
+            model_dict['seeds.yml'] = schema_seed_delete_insert_yml
+        return model_dict


### PR DESCRIPTION
### Description

Fixes 1.0 tests since by default columns are not nullable but we're writing a null value.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have run `changie new` and committed everything in .changes folder
- [x] I have removed any print or log calls that were added for debugging.
- [x] I have verified that this PR contains only code changes relevant to this PR.
- [x] If further integration tests are now passing I've edited tests/functional/adapter/* to account for this.
- [x] I have pulled/merged from the main branch if there are merge conflicts.
- [x] After pulling/merging main I have run pytest on the included or updated tests/functional/adapter/.
