### PR TITLE
ci: Bump version automatically on release

### DIFF
--- a/.github/workflows/python-release-org.yml
+++ b/.github/workflows/python-release-org.yml
@@ -10,8 +10,9 @@ on:
         required: false
         description: 'Trigger a major release (optional). Leave empty for regular release.'
       version:
-        required: true
-        description: 'Version to release. Should be aligned with dbt-core.'
+        required: false
+        description: 'Version to release (optional). Leave empty to auto-detect from commits.'
+        default: ''
 
 jobs:
   integration-tests:


### PR DESCRIPTION
We no longer need to align versions with dbt-core. This means that we can auto-bump the version like in other python-based repos.
Making the version parameter optional so our shared GH action can bump version based on commit messages.